### PR TITLE
Support URLs for Postgrex configuration

### DIFF
--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -1,0 +1,37 @@
+defmodule EventStore.Config do
+  
+  @doc """
+  Normalizes the application configuration.
+  """
+  def parse(config) do
+    {url, config} = Keyword.pop(config, :url)
+    Keyword.merge(config, parse_url(url || ""))
+  end
+
+  @doc """
+  Converts a database url into a Keyword list
+  """
+  def parse_url(""), do: []
+  def parse_url(url) do
+    info = url |> URI.decode() |> URI.parse()
+
+    if is_nil(info.host) do
+      raise ArgumentError, message: "host is not present"
+    end
+
+    if is_nil(info.path) or not (info.path =~ ~r"^/([^/])+$") do
+      raise ArgumentError, message: "path should be a database name"
+    end
+
+    destructure [username, password], info.userinfo && String.split(info.userinfo, ":")
+    "/" <> database = info.path
+
+    opts = [username: username,
+            password: password,
+            database: database,
+            hostname: info.host,
+            port:     info.port]
+
+    Enum.reject(opts, fn {_k, v} -> is_nil(v) end)
+  end
+end

--- a/lib/event_store/storage/pool_supervisor.ex
+++ b/lib/event_store/storage/pool_supervisor.ex
@@ -1,6 +1,8 @@
 defmodule EventStore.Storage.PoolSupervisor do
   use Supervisor
 
+  alias EventStore.Config
+
   @storage_pool_name :event_store_storage_pool
 
   def start_link do
@@ -15,7 +17,7 @@ defmodule EventStore.Storage.PoolSupervisor do
       {:max_overflow, 5}
     ]
 
-    storage_config = Application.get_env(:eventstore, EventStore.Storage)
+    storage_config = Config.parse Application.get_env(:eventstore, EventStore.Storage)
 
     children = [
       :poolboy.child_spec(@storage_pool_name, storage_pool_config, storage_config)
@@ -23,4 +25,5 @@ defmodule EventStore.Storage.PoolSupervisor do
 
     supervise(children, strategy: :one_for_one)
   end
+
 end

--- a/lib/mix/tasks/event_store.create.ex
+++ b/lib/mix/tasks/event_store.create.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.EventStore.Create do
   def run(args) do
     Application.ensure_all_started(:postgrex)
 
-    config = Application.get_env(:eventstore, Storage)
+    config = EventStore.Config.parse Application.get_env(:eventstore, Storage)
     {opts, _, _} = OptionParser.parse(args, switches: [quiet: :boolean])
 
     create_database(config, opts)

--- a/lib/mix/tasks/event_store.drop.ex
+++ b/lib/mix/tasks/event_store.drop.ex
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.EventStore.Drop do
 
   @doc false
   def run(_args) do
-    config = Application.get_env(:eventstore, Storage)
+    config = EventStore.Config.parse Application.get_env(:eventstore, Storage)
 
     if skip_safety_warnings?() or Mix.shell.yes?("Are you sure you want to drop the EventStore database?") do
       drop_database(config)

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -1,0 +1,31 @@
+defmodule EventStore.ConfigTest do
+  use ExUnit.Case
+
+  alias EventStore.Config
+
+  test "parse keys" do
+    original = [
+      username: "postgres",
+      password: "postgres",
+      database: "eventstore_test",
+      hostname: "localhost"
+    ]
+    
+    config = Config.parse original
+    assert config == original
+  end
+
+  test "parse url" do
+    original = [ url: "postgres://username:password@localhost/database" ]
+    
+    config = Config.parse original
+    assert config == [
+      username: "username",
+      password: "password",
+      database: "database",
+      hostname: "localhost"
+    ]
+    
+  end
+  
+end

--- a/test/storage/database_test.exs
+++ b/test/storage/database_test.exs
@@ -2,11 +2,11 @@ defmodule EventStore.Storage.DatabaseTest do
   use ExUnit.Case
   doctest EventStore.Storage.Database
 
-  alias EventStore.Storage
+  alias EventStore.{ Storage, Config }
   alias EventStore.Storage.Database
 
   def temp_database_config do
-    config = Application.get_env(:eventstore, Storage)
+    config = Config.parse Application.get_env(:eventstore, Storage)
     Keyword.merge(config, [database: config[:database] <> "_temp"])
   end
 


### PR DESCRIPTION
To make things a little easier when deploying (esp. Heroku) here's a small change to allow you to use URLs for the database configuration.

```elixir
   config :eventstore, EventStore.Storage,
      url: "postgres://username:password@host/database"
```

Let me know if there is anything I'm missing, I wasn't quite sure on the README - since what you have there is super clean and gets you up and running quickly, felt this may distract from that.