### PR TITLE
Buffer events between publisher and subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@
 
 ### Enhancements
 
-- Ack handled events in subscribers ([#18](https://github.com/slashdotdash/eventstore/issues/18))
+- Ack handled events in subscribers ([#18](https://github.com/slashdotdash/eventstore/issues/18)).
+- Buffer events between publisher and subscriber ([#19](https://github.com/slashdotdash/eventstore/issues/19)).

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Receipt of each event by the subscriber must be acknowledged. This allows the su
 
 The subscriber receives an `{:events, events, subscription}` tuple containing the published events and the subscription to send the `ack` to. This is achieved by sending an `{:ack, last_seen_event_id}` tuple to the `subscription` process. A subscriber can confirm receipt of each event in a batch by sending multiple acks, one per event. Or just confirm receipt of the last event in the batch.
 
-A subscriber will not receive further published events until it has confirmed receipt of all received events. This provides back pressure to the subscription to prevent the subscriber from being overwhelmed with messages if it cannot keep up.
+A subscriber will not receive further published events until it has confirmed receipt of all received events. This provides back pressure to the subscription to prevent the subscriber from being overwhelmed with messages if it cannot keep up. The subscription will buffer events until the subscriber is ready to receive, or an overflow occurs. At which point it will move into a catch-up mode and query events and replay them from storage until caught up.
 
 #### Example subscriber
 

--- a/lib/event_store/subscriptions.ex
+++ b/lib/event_store/subscriptions.ex
@@ -134,6 +134,7 @@ defmodule EventStore.Subscriptions do
   end
 
   defp notify_subscribers([], _recorded_events, _serializer), do: nil
+  defp notify_subscribers(_subscriptions, [], _serializer), do: nil
   defp notify_subscribers(subscriptions, recorded_events, serializer) do
     events = Enum.map(recorded_events, fn event -> deserialize_recorded_event(event, serializer) end)
 

--- a/lib/event_store/subscriptions/stream_subscription.ex
+++ b/lib/event_store/subscriptions/stream_subscription.ex
@@ -9,7 +9,8 @@ defmodule EventStore.Subscriptions.StreamSubscription do
               subscriber: nil,
               last_seen: 0,
               last_ack: 0,
-              pending_events: []
+              pending_events: [],
+              max_size: nil
   end
 
   alias EventStore.Storage
@@ -18,9 +19,10 @@ defmodule EventStore.Subscriptions.StreamSubscription do
   use Fsm, initial_state: :initial, initial_data: %SubscriptionData{}
 
   @all_stream "$all"
+  @max_buffer_size 1_000
 
   defstate initial do
-    defevent subscribe(stream_uuid, stream, subscription_name, source, subscriber), data: %SubscriptionData{} = data do
+    defevent subscribe(stream_uuid, stream, subscription_name, source, subscriber, opts), data: %SubscriptionData{} = data do
       case subscribe_to_stream(stream_uuid, subscription_name) do
         {:ok, subscription} ->
           last_ack = subscription_provider(stream_uuid).last_ack(subscription) || 0
@@ -32,8 +34,10 @@ defmodule EventStore.Subscriptions.StreamSubscription do
             source: source,
             subscriber: subscriber,
             last_seen: last_ack,
-            last_ack: last_ack
+            last_ack: last_ack,
+            max_size: opts[:max_size] || @max_buffer_size
           }
+
           next_state(:catching_up, data)
 
         {:error, _reason} ->
@@ -50,10 +54,10 @@ defmodule EventStore.Subscriptions.StreamSubscription do
           next_state(:subscribed, data)
 
         {:ok, ^last_seen} ->
-          # already seen latest stream version
+          # already seen latest event
           next_state(:subscribed, data)
 
-        {:ok, _last_seen} ->
+        {:ok, _latest_event} ->
           # must catch-up with all unseen events from stream
           data = catch_up_from_stream(data)
 
@@ -62,9 +66,7 @@ defmodule EventStore.Subscriptions.StreamSubscription do
     end
 
     defevent ack(ack), data: %SubscriptionData{} = data do
-      ack_events(data, ack)
-
-      data = %SubscriptionData{data| last_ack: ack}
+      data = ack_events(data, ack)
 
       next_state(:catching_up, data)
     end
@@ -82,7 +84,7 @@ defmodule EventStore.Subscriptions.StreamSubscription do
 
   defstate subscribed do
     # notify events for single stream subscription
-    defevent notify_events(events), data: %SubscriptionData{stream_uuid: stream_uuid, last_seen: last_seen, last_ack: last_ack, pending_events: pending_events} = data do
+    defevent notify_events(events), data: %SubscriptionData{stream_uuid: stream_uuid, last_seen: last_seen, last_ack: last_ack, pending_events: pending_events, max_size: max_size} = data do
       expected_event = last_seen + 1
       next_ack = last_ack + 1
 
@@ -98,13 +100,18 @@ defmodule EventStore.Subscriptions.StreamSubscription do
           next_state(:subscribed, data)
 
         ^expected_event ->
-          # subscriber has not yet ack'd last seen stream version so enqueue them until they are ready
+          # subscriber has not yet ack'd last seen event so enqueue them until they are ready
           data = %SubscriptionData{data |
             last_seen: subscription_provider(stream_uuid).event_id(List.last(events)),
             pending_events: pending_events ++ events
           }
 
-          next_state(:subscribed, data)
+          if length(pending_events) + length(events) >= max_size do
+            # subscriber is too far behind, must wait for it to catch up
+            next_state(:max_capacity, data)
+          else
+            next_state(:subscribed, data)
+          end
 
         _ ->
           # must catch-up with all unseen events
@@ -112,15 +119,11 @@ defmodule EventStore.Subscriptions.StreamSubscription do
       end
     end
 
-    defevent ack(ack), data: %SubscriptionData{pending_events: pending_events} = data do
-      ack_events(data, ack)
-
-      notify_subscriber(data, pending_events)
-
-      data = %SubscriptionData{data|
-        pending_events: [],
-        last_ack: ack
-      }
+    defevent ack(ack), data: %SubscriptionData{} = data do
+      data =
+        data
+        |> ack_events(ack)
+        |> notify_pending_events
 
       next_state(:subscribed, data)
     end
@@ -135,8 +138,45 @@ defmodule EventStore.Subscriptions.StreamSubscription do
     end
   end
 
+  defstate max_capacity do
+    # ignore event notifications while catching up
+    defevent notify_events(_events), data: %SubscriptionData{} = data do
+      next_state(:max_capacity, data)
+    end
+
+    defevent ack(ack), data: %SubscriptionData{} = data do
+      data =
+        data
+        |> ack_events(ack)
+        |> notify_pending_events
+
+      next_state(:catching_up, data)
+    end
+
+    defevent catch_up, data: %SubscriptionData{} = data do
+      next_state(:max_capacity, data)
+    end
+
+    defevent unsubscribe, data: %SubscriptionData{stream_uuid: stream_uuid, subscription_name: subscription_name} = data do
+      unsubscribe_from_stream(stream_uuid, subscription_name)
+      next_state(:unsubscribed, data)
+    end
+  end
+
   defstate unsubscribed do
     defevent notify_events(_events), data: %SubscriptionData{} = data do
+      next_state(:unsubscribed, data)
+    end
+
+    defevent ack(_ack), data: %SubscriptionData{} = data do
+      next_state(:unsubscribed, data)
+    end
+
+    defevent catch_up, data: %SubscriptionData{} = data do
+      next_state(:unsubscribed, data)
+    end
+
+    defevent unsubscribe, data: %SubscriptionData{} = data do
       next_state(:unsubscribed, data)
     end
   end
@@ -160,21 +200,32 @@ defmodule EventStore.Subscriptions.StreamSubscription do
 
   defp catch_up_from_stream(%SubscriptionData{stream_uuid: stream_uuid, stream: stream, last_seen: last_seen} = data) do
     last_event = case subscription_provider(stream_uuid).unseen_events(stream, last_seen) do
-      {:ok, events} ->
-        # chunk events by correlation id
-        events
-        |> Enum.chunk_by(fn event -> event.correlation_id end)
-        |> Enum.map(fn events_by_correlation_id ->
-          last_event = List.last(events_by_correlation_id)
-
-          notify_subscriber(data, events_by_correlation_id)
-
-          last_event
-        end)
-        |> Enum.reduce(fn (last_event, _) -> last_event end)
+      {:ok, events} -> notify_subscriber_events(data, events)
     end
 
     %SubscriptionData{data | last_seen: subscription_provider(stream_uuid).event_id(last_event)}
+  end
+
+  # chunk events by correlation id and send to subscriber
+  # returns the last notified event
+  defp notify_subscriber_events(%SubscriptionData{} = data, events) do
+    events
+    |> Enum.chunk_by(fn event -> event.correlation_id end)
+    |> Enum.map(fn events_by_correlation_id ->
+      notify_subscriber(data, events_by_correlation_id)
+
+      List.last(events_by_correlation_id)
+    end)
+    |> Enum.reduce(fn (last_event, _) -> last_event end)
+  end
+
+  defp notify_pending_events(%SubscriptionData{pending_events: []} = data), do: data
+  defp notify_pending_events(%SubscriptionData{pending_events: pending_events} = data) do
+    notify_subscriber_events(data, pending_events)
+
+    %SubscriptionData{data|
+      pending_events: []
+    }
   end
 
   defp notify_subscriber(%SubscriptionData{}, []) do
@@ -185,7 +236,9 @@ defmodule EventStore.Subscriptions.StreamSubscription do
     send(subscriber, {:events, events, source})
   end
 
-  defp ack_events(%SubscriptionData{stream_uuid: stream_uuid, subscription_name: subscription_name}, ack) do
+  defp ack_events(%SubscriptionData{stream_uuid: stream_uuid, subscription_name: subscription_name} = data, ack) do
     subscription_provider(stream_uuid).ack_last_seen_event(stream_uuid, subscription_name, ack)
+
+    %SubscriptionData{data| last_ack: ack}
   end
 end

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -42,7 +42,7 @@ defmodule EventStore.Subscriptions.Subscription do
   def handle_cast({:subscribe_to_stream}, %Subscription{stream_uuid: stream_uuid, stream: stream, subscription_name: subscription_name, subscriber: subscriber, subscription: subscription} = state) do
     subscription =
       subscription
-      |> StreamSubscription.subscribe(stream_uuid, stream, subscription_name, self, subscriber)
+      |> StreamSubscription.subscribe(stream_uuid, stream, subscription_name, self, subscriber, [])
 
     handle_subscription_state(subscription.state)
 

--- a/test/subscriptions/single_stream_subscription_test.exs
+++ b/test/subscriptions/single_stream_subscription_test.exs
@@ -19,9 +19,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     stream_uuid = UUID.uuid4
     {:ok, stream} = Streams.open_stream(stream_uuid)
 
-    subscription =
-      StreamSubscription.new
-      |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, nil, self)
+    subscription = create_subscription(stream_uuid, stream)
 
     assert subscription.state == :catching_up
     assert subscription.data.subscription_name == @subscription_name
@@ -34,8 +32,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     {:ok, stream} = Streams.open_stream(stream_uuid)
 
     subscription =
-      StreamSubscription.new
-      |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, nil, self)
+      create_subscription(stream_uuid, stream)
       |> StreamSubscription.catch_up
 
     assert subscription.state == :subscribed
@@ -51,8 +48,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     {:ok, stream} = Streams.open_stream(stream_uuid)
 
     subscription =
-      StreamSubscription.new
-      |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, nil, self)
+      create_subscription(stream_uuid, stream)
       |> StreamSubscription.catch_up
 
     assert subscription.state == :subscribed
@@ -72,8 +68,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     events = EventFactory.create_recorded_events(1, 1)
 
     subscription =
-      StreamSubscription.new
-      |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, nil, self)
+      create_subscription(stream_uuid, stream)
       |> StreamSubscription.catch_up
       |> StreamSubscription.notify_events(events)
 
@@ -93,8 +88,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     {:ok, stream} = Streams.open_stream(stream_uuid)
 
     subscription =
-      StreamSubscription.new
-      |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, nil, self)
+      create_subscription(stream_uuid, stream)
       |> StreamSubscription.catch_up
 
     assert subscription.state == :subscribed
@@ -111,8 +105,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     assert subscription.data.last_ack == 3
 
     subscription =
-      StreamSubscription.new
-      |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, nil, self)
+      create_subscription(stream_uuid, stream)
       |> StreamSubscription.catch_up
 
     # should not receive already seen events
@@ -131,8 +124,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     {:ok, stream} = Streams.open_stream(stream_uuid)
 
     subscription =
-      StreamSubscription.new
-      |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, nil, self)
+      create_subscription(stream_uuid, stream)
       |> StreamSubscription.catch_up
 
     assert subscription.state == :subscribed
@@ -143,8 +135,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     assert length(received_events) == 3
 
     subscription =
-      StreamSubscription.new
-      |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, nil, self)
+      create_subscription(stream_uuid, stream)
       |> StreamSubscription.catch_up
 
     # should receive already seen events
@@ -165,8 +156,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     {:ok, stream} = Streams.open_stream(stream_uuid)
 
     subscription =
-      StreamSubscription.new
-      |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, nil, self)
+      create_subscription(stream_uuid, stream)
       |> StreamSubscription.catch_up
       |> StreamSubscription.notify_events(initial_events)
       |> StreamSubscription.notify_events(remaining_events)
@@ -196,6 +186,11 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
    assert length(received_events) == 3
    assert pluck(received_events, :correlation_id) == pluck(remaining_events, :correlation_id)
    assert pluck(received_events, :data) == pluck(remaining_events, :data)
+  end
+
+  defp create_subscription(stream_uuid, stream, opts \\ []) do
+    StreamSubscription.new
+    |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, nil, self, opts)
   end
 
   defp pluck(enumerable, field) do

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -114,6 +114,8 @@ defmodule EventStore.Subscriptions.SubscribeToStream do
 
       # subscription 2 should still receive events
       assert_receive {:events, received_events}, @receive_timeout
+      refute_receive {:events, _events}, @receive_timeout
+
       assert pluck(received_events, :data) == pluck(events, :data)
       assert pluck(Subscriber.received_events(subscriber2), :data) == pluck(events, :data)
     end

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -131,10 +131,13 @@ defmodule EventStore.Subscriptions.SubscribeToStream do
       :ok = Stream.append_to_stream(stream, 0, initial_events)
 
       assert_receive {:events, initial_received_events, ^subscription}, @receive_timeout
+      assert length(initial_received_events) == 3
       assert pluck(initial_received_events, :data) == pluck(initial_events, :data)
 
       # acknowledge receipt of first event only
       send(subscription, {:ack, 1})
+
+      refute_receive {:events, _events, ^subscription}, @receive_timeout
 
       # should not send further events until ack'd all previous
       :ok = Stream.append_to_stream(stream, 3, remaining_events)
@@ -145,6 +148,7 @@ defmodule EventStore.Subscriptions.SubscribeToStream do
       send(subscription, {:ack, 3})
 
       assert_receive {:events, remaining_received_events, ^subscription}, @receive_timeout
+      assert length(remaining_received_events) == 3
       assert pluck(remaining_received_events, :data) == pluck(remaining_events, :data)
     end
 


### PR DESCRIPTION
Prevent a subscriber to a single or all streams from being overloaded with published events. A limited size buffer is used by the subscription.

Fixes #19.