### PR TITLE
Subscriptions use Elixir streams to read events when catching up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.4
+
+### Enhancements
+
+- Subscriptions use Elixir [streams](https://hexdocs.pm/elixir/Stream.html) to read events when catching up.
+
 ## v0.7.3
 
 ### Enhancements

--- a/lib/event_store/storage/subscription.ex
+++ b/lib/event_store/storage/subscription.ex
@@ -8,7 +8,23 @@ defmodule EventStore.Storage.Subscription do
   alias EventStore.Sql.Statements
   alias EventStore.Storage.Subscription
 
-  defstruct subscription_id: nil, stream_uuid: nil, subscription_name: nil, last_seen_event_id: nil, last_seen_stream_version: nil, created_at: nil
+  @type t :: %EventStore.Storage.Subscription{
+    subscription_id: non_neg_integer(),
+    stream_uuid: String.t,
+    subscription_name: String.t,
+    last_seen_event_id: nil | non_neg_integer(),
+    last_seen_stream_version: nil | non_neg_integer(),
+    created_at: NaiveDateTime.t,
+  }
+  
+  defstruct [
+    subscription_id: nil,
+    stream_uuid: nil,
+    subscription_name: nil,
+    last_seen_event_id: nil,
+    last_seen_stream_version: nil,
+    created_at: nil,
+  ]
 
   @doc """
   List all known subscriptions

--- a/lib/event_store/streams/stream.ex
+++ b/lib/event_store/streams/stream.ex
@@ -30,6 +30,10 @@ defmodule EventStore.Streams.Stream do
     GenServer.call(stream, {:read_stream_forward, start_version, count})
   end
 
+  def stream_forward(stream, start_version, read_batch_size) do
+    GenServer.call(stream, {:stream_forward, start_version, read_batch_size})
+  end
+
   def subscribe_to_stream(stream, subscription_name, subscriber, start_from) do
     GenServer.call(stream, {:subscribe_to_stream, subscription_name, subscriber, start_from})
   end
@@ -62,6 +66,12 @@ defmodule EventStore.Streams.Stream do
 
   def handle_call({:read_stream_forward, start_version, count}, _from, %Stream{stream_id: stream_id, serializer: serializer} = state) do
     reply = read_storage_forward(stream_id, start_version, count, serializer)
+
+    {:reply, reply, state}
+  end
+
+  def handle_call({:stream_forward, start_version, read_batch_size}, _from, %Stream{stream_id: stream_id, serializer: serializer} = state) do
+    reply = stream_storage_forward(stream_id, start_version, read_batch_size, serializer)
 
     {:reply, reply, state}
   end
@@ -137,6 +147,21 @@ defmodule EventStore.Streams.Stream do
     end
   end
   defp read_storage_forward(_stream_id, _start_version, _count, _serializer), do: {:error, :stream_not_found}
+
+  defp stream_storage_forward(stream_id, 0, read_batch_size, serializer), do: stream_storage_forward(stream_id, 1, read_batch_size, serializer)
+  defp stream_storage_forward(stream_id, start_version, read_batch_size, serializer) do
+    Elixir.Stream.resource(
+      fn -> start_version end,
+      fn next_version ->
+        case read_storage_forward(stream_id, next_version, read_batch_size, serializer) do
+          {:ok, []} -> {:halt, next_version}
+          {:ok, events} -> {events, next_version + length(events)}
+          {:error, _reason} -> {:halt, next_version}
+        end
+      end,
+      fn _ -> :ok end
+    )
+  end
 
   defp deserialize_recorded_events(recorded_events, serializer) do
     Enum.map(recorded_events, &deserialize_recorded_event(&1, serializer))

--- a/lib/event_store/subscriptions/all_streams_subscription.ex
+++ b/lib/event_store/subscriptions/all_streams_subscription.ex
@@ -1,4 +1,6 @@
 defmodule EventStore.Subscriptions.AllStreamsSubscription do
+  @behaviour EventStore.Subscriptions.StreamSubscriptionProvider
+
   alias EventStore.Storage
   alias EventStore.Streams.AllStream
 
@@ -12,10 +14,8 @@ defmodule EventStore.Subscriptions.AllStreamsSubscription do
     last_seen_event_id
   end
 
-  def unseen_events(_stream, last_seen_event_id, count) do
-    start_event_id = last_seen_event_id + 1
-
-    AllStream.read_stream_forward(start_event_id, count)
+  def unseen_event_stream(_stream, last_seen, read_batch_size) do
+    AllStream.stream_forward(last_seen + 1, read_batch_size)
   end
 
   def ack_last_seen_event(@all_stream, subscription_name, last_event_id) do

--- a/lib/event_store/subscriptions/single_stream_subscription.ex
+++ b/lib/event_store/subscriptions/single_stream_subscription.ex
@@ -1,4 +1,6 @@
 defmodule EventStore.Subscriptions.SingleStreamSubscription do
+  @behaviour EventStore.Subscriptions.StreamSubscriptionProvider
+
   alias EventStore.Storage
   alias EventStore.Streams.Stream
 
@@ -10,13 +12,8 @@ defmodule EventStore.Subscriptions.SingleStreamSubscription do
     last_seen_stream_version
   end
 
-  def unseen_events(stream, last_seen_stream_version, count) do
-    start_version = last_seen_stream_version + 1
-
-    case Stream.read_stream_forward(stream, start_version, count) do
-      {:ok, _events} = reply -> reply
-      {:error, :stream_not_found} -> {:ok, []}
-    end
+  def unseen_event_stream(stream, last_seen, read_batch_size) do
+    Stream.stream_forward(stream, last_seen + 1, read_batch_size)
   end
 
   def ack_last_seen_event(stream_uuid, subscription_name, last_stream_version) do

--- a/lib/event_store/subscriptions/stream_subscription.ex
+++ b/lib/event_store/subscriptions/stream_subscription.ex
@@ -31,7 +31,7 @@ defmodule EventStore.Subscriptions.StreamSubscription do
             max_size: opts[:max_size] || @max_buffer_size
           }
 
-          next_state(:catching_up, data)
+          next_state(:request_catch_up, data)
 
         {:error, _reason} ->
           next_state(:failed, data)
@@ -39,11 +39,36 @@ defmodule EventStore.Subscriptions.StreamSubscription do
     end
   end
 
+  defstate request_catch_up do
+    defevent catch_up, data: %SubscriptionState{} = data do
+      catch_up_from_stream(data)
+
+      next_state(:catching_up, data)
+    end
+
+    defevent ack(ack), data: %SubscriptionState{} = data do
+      data =
+        data
+        |> ack_events(ack)
+        |> notify_pending_events
+
+      next_state(:request_catch_up, data)
+    end
+
+    # ignore event notifications while catching up
+    defevent notify_events(_events), data: %SubscriptionState{} = data do
+      next_state(:request_catch_up, data)
+    end
+
+    defevent unsubscribe, data: %SubscriptionState{stream_uuid: stream_uuid, subscription_name: subscription_name} = data do
+      unsubscribe_from_stream(stream_uuid, subscription_name)
+      next_state(:unsubscribed, data)
+    end
+  end
+
   defstate catching_up do
     defevent catch_up, data: %SubscriptionState{} = data do
-      {state, data} = catch_up_from_stream(data)
-
-      next_state(state, data)
+      next_state(:catching_up, data)
     end
 
     defevent ack(ack), data: %SubscriptionState{} = data do
@@ -53,6 +78,14 @@ defmodule EventStore.Subscriptions.StreamSubscription do
         |> notify_pending_events
 
       next_state(:catching_up, data)
+    end
+
+    defevent caught_up(last_seen), data: %SubscriptionState{} = data do
+      data = %SubscriptionState{data |
+        last_seen: last_seen,
+      }
+
+      next_state(:subscribed, data)
     end
 
     # ignore event notifications while catching up
@@ -99,7 +132,7 @@ defmodule EventStore.Subscriptions.StreamSubscription do
 
         _ ->
           # must catch-up with all unseen events
-          next_state(:catching_up, data)
+          next_state(:request_catch_up, data)
       end
     end
 
@@ -113,7 +146,7 @@ defmodule EventStore.Subscriptions.StreamSubscription do
     end
 
     defevent catch_up, data: %SubscriptionState{} = data do
-      next_state(:catching_up, data)
+      next_state(:request_catch_up, data)
     end
 
     defevent unsubscribe, data: %SubscriptionState{stream_uuid: stream_uuid, subscription_name: subscription_name} = data do
@@ -137,7 +170,7 @@ defmodule EventStore.Subscriptions.StreamSubscription do
       case data.pending_events do
         [] ->
           # no further pending events so catch up with any unseen
-          next_state(:catching_up, data)
+          next_state(:request_catch_up, data)
 
         _ ->
           # pending events remain, wait until subscriber ack's
@@ -192,43 +225,39 @@ defmodule EventStore.Subscriptions.StreamSubscription do
 
   # fetch unseen events from the stream
   # transition to `subscribed` state when no events are found or count of events is less than max buffer size so no further unseen events
-  defp catch_up_from_stream(%SubscriptionState{stream_uuid: stream_uuid, stream: stream, last_seen: last_seen} = data) do
-    case subscription_provider(stream_uuid).unseen_events(stream, last_seen, @max_buffer_size) do
-      {:ok, []} -> {:subscribed, data}
-      {:ok, events} ->
-        last_event = notify_subscriber_events(data, events)
-        data = %SubscriptionState{data | last_seen: subscription_provider(stream_uuid).event_id(last_event)}
+  defp catch_up_from_stream(%SubscriptionState{stream_uuid: stream_uuid, stream: stream, last_seen: last_seen, source: source} = data) do
+    unseen_event_stream = subscription_provider(stream_uuid).unseen_event_stream(stream, last_seen, @max_buffer_size)
 
-        if length(events) < @max_buffer_size do
-          {:subscribed, data}
-        else
-          {:catching_up, data}
-        end
-    end
-  end
+    # stream through unseen events in a separate process
+    spawn_link(fn ->
+      last_event =
+        unseen_event_stream
+        |> Stream.chunk_by(&(&1.correlation_id))
+        |> Stream.each(&notify_subscriber(data, &1))
+        |> Stream.map(&Enum.at(&1, -1))
+        |> Enum.at(-1)
 
-  # chunk events by correlation id and send to subscriber
-  # returns the last notified event
-  defp notify_subscriber_events(%SubscriptionState{} = data, events) do
-    events
-    |> Enum.chunk_by(fn event -> event.correlation_id end)
-    |> Enum.map(fn events_by_correlation_id ->
-      notify_subscriber(data, events_by_correlation_id)
+      last_seen = case last_event do
+        nil -> 0
+        event -> subscription_provider(stream_uuid).event_id(event)
+      end
 
-      List.last(events_by_correlation_id)
+      # notify subscription caught up to given last seen event
+      send(source, {:caught_up, last_seen})
     end)
-    |> Enum.reduce(fn (last_event, _) -> last_event end)
   end
 
   # send pending events to subscriber if ready to receive them
   defp notify_pending_events(%SubscriptionState{pending_events: []} = data), do: data
-  defp notify_pending_events(%SubscriptionState{pending_events: [first_pending_event|_] = pending_events, stream_uuid: stream_uuid, last_ack: last_ack} = data) do
+  defp notify_pending_events(%SubscriptionState{pending_events: [first_pending_event | _] = pending_events, stream_uuid: stream_uuid, last_ack: last_ack} = data) do
     next_ack = last_ack + 1
 
     case subscription_provider(stream_uuid).event_id(first_pending_event) do
       ^next_ack ->
         # subscriber has ack'd last received event, so send pending
-        notify_subscriber_events(data, pending_events)
+        pending_events
+        |> Enum.chunk_by(&(&1.correlation_id))
+        |> Enum.each(&notify_subscriber(data, &1))
 
         %SubscriptionState{data|
           pending_events: []

--- a/lib/event_store/subscriptions/stream_subscription.ex
+++ b/lib/event_store/subscriptions/stream_subscription.ex
@@ -225,7 +225,7 @@ defmodule EventStore.Subscriptions.StreamSubscription do
 
   # fetch unseen events from the stream
   # transition to `subscribed` state when no events are found or count of events is less than max buffer size so no further unseen events
-  defp catch_up_from_stream(%SubscriptionState{stream_uuid: stream_uuid, stream: stream, last_seen: last_seen, source: source} = data, notification_callback) do
+  defp catch_up_from_stream(%SubscriptionState{stream_uuid: stream_uuid, stream: stream, last_seen: last_seen} = data, notification_callback) do
     unseen_event_stream = subscription_provider(stream_uuid).unseen_event_stream(stream, last_seen, @max_buffer_size)
 
     # stream through unseen events in a separate process

--- a/lib/event_store/subscriptions/stream_subscription_provider.ex
+++ b/lib/event_store/subscriptions/stream_subscription_provider.ex
@@ -1,0 +1,30 @@
+defmodule EventStore.Subscriptions.StreamSubscriptionProvider do
+  @moduledoc """
+  Specification to access subscription related event info from a single, or all streams
+  """
+
+  @type event :: EventStore.RecordedEvent.t
+  @type subscription :: EventStore.Storage.Subscription.t
+  @type stream :: pid()
+  @type stream_uuid :: String.t
+  @type subscription_name :: String.t
+  @type last_seen :: non_neg_integer()
+  @type read_batch_size :: non_neg_integer()
+
+  @doc """
+  Get the stream identity from the given event.
+  """
+  @callback event_id(event) :: non_neg_integer()
+
+  @doc """
+  Get the last ack'd event for the given subscription
+  """
+  @callback last_ack(subscription) :: non_neg_integer()
+
+  @doc """
+  Get a stream of events since the last seen, fetched in batches limited to given size
+  """
+  @callback unseen_event_stream(stream, last_seen, read_batch_size) :: Enumerable.t
+
+  @callback ack_last_seen_event(stream_uuid, subscription_name, last_seen) :: :ok | {:error, reason :: any()}
+end

--- a/lib/event_store/subscriptions/stream_subscription_provider.ex
+++ b/lib/event_store/subscriptions/stream_subscription_provider.ex
@@ -26,5 +26,8 @@ defmodule EventStore.Subscriptions.StreamSubscriptionProvider do
   """
   @callback unseen_event_stream(stream, last_seen, read_batch_size) :: Enumerable.t
 
+  @doc """
+  Acknowledge receipt of the last seen event for the stream and subscription
+  """
   @callback ack_last_seen_event(stream_uuid, subscription_name, last_seen) :: :ok | {:error, reason :: any()}
 end

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -83,6 +83,18 @@ defmodule EventStore.Subscriptions.Subscription do
     {:noreply, state}
   end
 
+  def handle_info({:caught_up, last_seen}, %Subscription{subscription: subscription} = state) do
+    subscription =
+      subscription
+      |> StreamSubscription.caught_up(last_seen)
+
+    state = %Subscription{state | subscription: subscription}
+
+    handle_subscription_state(state)
+
+    {:noreply, state}
+  end
+
   @doc """
   Confirm receipt of an event by id
   """
@@ -112,7 +124,7 @@ defmodule EventStore.Subscriptions.Subscription do
     {:reply, :ok, state}
   end
 
-  defp handle_subscription_state(%Subscription{subscription: %{state: :catching_up}}) do
+  defp handle_subscription_state(%Subscription{subscription: %{state: :request_catch_up}}) do
     GenServer.cast(self(), {:catch_up})
   end
 

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -68,11 +68,11 @@ defmodule EventStore.Subscriptions.Subscription do
   end
 
   def handle_cast({:catch_up}, %Subscription{subscription: subscription} = state) do
-    self = self()
+    reply_to = self()
 
     subscription = StreamSubscription.catch_up(subscription, fn last_seen ->
       # notify subscription caught up to given last seen event
-      send(self, {:caught_up, last_seen})
+      send(reply_to, {:caught_up, last_seen})
     end)
 
     state = %Subscription{state | subscription: subscription}

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -48,9 +48,7 @@ defmodule EventStore.Subscriptions.Subscription do
   end
 
   def handle_cast({:subscribe_to_stream}, %Subscription{stream_uuid: stream_uuid, stream: stream, subscription_name: subscription_name, subscriber: subscriber, subscription: subscription, subscription_opts: opts} = state) do
-    subscription =
-      subscription
-      |> StreamSubscription.subscribe(stream_uuid, stream, subscription_name, self(), subscriber, opts)
+    subscription = StreamSubscription.subscribe(subscription, stream_uuid, stream, subscription_name, self(), subscriber, opts)
 
     state = %Subscription{state | subscription: subscription}
 
@@ -60,9 +58,7 @@ defmodule EventStore.Subscriptions.Subscription do
   end
 
   def handle_cast({:notify_events, events}, %Subscription{subscription: subscription} = state) do
-    subscription =
-      subscription
-      |> StreamSubscription.notify_events(events)
+    subscription = StreamSubscription.notify_events(subscription, events)
 
     state = %Subscription{state | subscription: subscription}
 
@@ -72,9 +68,12 @@ defmodule EventStore.Subscriptions.Subscription do
   end
 
   def handle_cast({:catch_up}, %Subscription{subscription: subscription} = state) do
-    subscription =
-      subscription
-      |> StreamSubscription.catch_up
+    self = self()
+
+    subscription = StreamSubscription.catch_up(subscription, fn last_seen ->
+      # notify subscription caught up to given last seen event
+      send(self, {:caught_up, last_seen})
+    end)
 
     state = %Subscription{state | subscription: subscription}
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EventStore.Mixfile do
   def project do
     [
       app: :eventstore,
-      version: "0.7.3",
+      version: "0.7.4",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env),
       description: description(),

--- a/test/streams/single_stream_test.exs
+++ b/test/streams/single_stream_test.exs
@@ -77,12 +77,12 @@ defmodule EventStore.Streams.StreamTest do
     {:error, :stream_not_found} = Stream.read_stream_forward(stream, 0, 1)
   end
 
-  # test "attempt to stream an unknown stream should error stream not found" do
-  #   unknown_stream_uuid = UUID.uuid4
-  #   {:ok, stream} = Streams.open_stream(unknown_stream_uuid)
-  #
-  #   {:error, :stream_not_found} = Stream.stream_forward(stream, 0, 1) |> Stream.run
-  # end
+  test "attempt to stream an unknown stream should error stream not found" do
+    unknown_stream_uuid = UUID.uuid4
+    {:ok, stream} = Streams.open_stream(unknown_stream_uuid)
+
+    {:error, :stream_not_found} = Stream.stream_forward(stream, 0, 1)
+  end
 
   describe "read stream forward" do
     setup [:append_events_to_stream]

--- a/test/subscriptions/all_streams_subscription_test.exs
+++ b/test/subscriptions/all_streams_subscription_test.exs
@@ -18,7 +18,7 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
   test "create subscription to all streams" do
     subscription = create_subscription()
 
-    assert subscription.state == :catching_up
+    assert subscription.state == :request_catch_up
     assert subscription.data.subscription_name == @subscription_name
     assert subscription.data.subscriber == self()
     assert subscription.data.last_seen == 0
@@ -28,7 +28,7 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
   test "create subscription to all streams from starting event id" do
     subscription = create_subscription(start_from_event_id: 2)
 
-    assert subscription.state == :catching_up
+    assert subscription.state == :request_catch_up
     assert subscription.data.subscription_name == @subscription_name
     assert subscription.data.subscriber == self()
     assert subscription.data.last_seen == 2
@@ -36,15 +36,23 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
   end
 
   test "catch-up subscription, no persisted events" do
+    self = self()
+
     subscription =
       create_subscription()
-      |> StreamSubscription.catch_up
+      |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
+
+    assert subscription.state == :catching_up
+    assert_receive {:caught_up, 0}
+
+    subscription = StreamSubscription.caught_up(subscription, 0)
 
     assert subscription.state == :subscribed
     assert subscription.data.last_seen == 0
   end
 
   test "catch-up subscription, unseen persisted events", %{conn: conn} do
+    self = self()
     stream_uuid = UUID.uuid4
     {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
     recorded_events = EventFactory.create_recorded_events(3, stream_id)
@@ -52,7 +60,12 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
 
     subscription =
       create_subscription()
-      |> StreamSubscription.catch_up
+      |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
+
+    assert subscription.state == :catching_up
+    assert_receive {:caught_up, 3}
+
+    subscription = StreamSubscription.caught_up(subscription, 3)
 
     assert subscription.state == :subscribed
     assert subscription.data.last_seen == 3
@@ -69,7 +82,8 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
 
     subscription =
       create_subscription()
-      |> StreamSubscription.catch_up
+      |> StreamSubscription.catch_up(fn last_seen -> last_seen end)
+      |> StreamSubscription.caught_up(0)
       |> StreamSubscription.notify_events(events)
 
     assert subscription.state == :subscribed
@@ -81,25 +95,11 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
   end
 
   describe "ack notified events" do
-    test "should skip events during catch up when acknowledged", %{conn: conn} do
-      stream_uuid = UUID.uuid4
-      {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
-      {:ok, 3} = Appender.append(conn, stream_id, EventFactory.create_recorded_events(3, stream_id))
+    setup [:append_events_to_stream, :create_caught_up_subscription]
 
-      subscription =
-        create_subscription()
-        |> StreamSubscription.catch_up
-
-      assert subscription.state == :subscribed
-      assert subscription.data.last_seen == 3
-      assert subscription.data.last_ack == 0
-
-      assert_receive {:events, received_events, nil}
-      assert length(received_events) == 3
-
-      subscription =
-        subscription
-        |> StreamSubscription.ack(3)
+    test "should skip events during catch up when acknowledged", %{subscription: subscription} do
+      self = self()
+      subscription = StreamSubscription.ack(subscription, 3)
 
       assert subscription.state == :subscribed
       assert subscription.data.last_seen == 3
@@ -107,83 +107,109 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
 
       subscription =
         create_subscription()
-        |> StreamSubscription.catch_up
+        |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
+
+      assert_receive {:caught_up, 3}
 
       # should not receive already seen events
       refute_receive {:events, _received_events, nil}
+
+      subscription = StreamSubscription.caught_up(subscription, 3)
 
       assert subscription.state == :subscribed
       assert subscription.data.last_seen == 3
       assert subscription.data.last_ack == 3
     end
 
-    test "should replay events when catching up and events had not been acknowledged", %{conn: conn} do
-      stream_uuid = UUID.uuid4
-      {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
-      {:ok, 3} = Appender.append(conn, stream_id, EventFactory.create_recorded_events(3, stream_id))
-
+    test "should replay events when catching up and events had not been acknowledged" do
+      self = self()
       subscription =
         create_subscription()
-        |> StreamSubscription.catch_up
-
-      assert subscription.state == :subscribed
-
-      assert_receive {:events, received_events, nil}
-      assert length(received_events) == 3
-      assert subscription.data.last_seen == 3
-      assert subscription.data.last_ack == 0
-
-      subscription =
-        create_subscription()
-        |> StreamSubscription.catch_up
+        |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
 
       # should receive already seen events
       assert_receive {:events, received_events, nil}
       assert length(received_events) == 3
 
+      assert_receive {:caught_up, 3}
+
+      subscription = StreamSubscription.caught_up(subscription, 3)
+
       assert subscription.state == :subscribed
       assert subscription.data.last_seen == 3
       assert subscription.data.last_ack == 0
     end
 
-    test "should not notify events until ack received" do
-      events = EventFactory.create_recorded_events(6, 1)
-      initial_events = Enum.take(events, 3)
-      remaining_events = Enum.drop(events, 3)
+    def append_events_to_stream(%{conn: conn}) do
+      stream_uuid = UUID.uuid4
+      {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
+      {:ok, 3} = Appender.append(conn, stream_id, EventFactory.create_recorded_events(3, stream_id))
+
+      []
+    end
+
+    def create_caught_up_subscription(_context) do
+      self = self()
 
       subscription =
         create_subscription()
-        |> StreamSubscription.catch_up
-        |> StreamSubscription.notify_events(initial_events)
-        |> StreamSubscription.notify_events(remaining_events)
+        |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
+
+      assert subscription.state == :catching_up
+
+      assert_receive {:events, received_events, nil}
+      assert length(received_events) == 3
+
+      assert_receive {:caught_up, 3}
+
+      subscription = StreamSubscription.caught_up(subscription, 3)
 
       assert subscription.state == :subscribed
+      assert subscription.data.last_seen == 3
+      assert subscription.data.last_ack == 0
 
-      # only receive initial events
-      assert_receive {:events, received_events, nil}
-      refute_receive {:events, _received_events, nil}
-
-      assert length(received_events) == 3
-      assert pluck(received_events, :correlation_id) == pluck(initial_events, :correlation_id)
-      assert pluck(received_events, :data) == pluck(initial_events, :data)
-
-      # don't receive remaining events until ack received for all initial events
-      subscription = ack_refute_receive(subscription, 1)
-      subscription = ack_refute_receive(subscription, 2)
-
-      subscription =
-        subscription
-        |> StreamSubscription.ack(3)
-
-      assert subscription.state == :subscribed
-
-      # now receive all remaining events
-      assert_receive {:events, received_events, nil}
-
-      assert length(received_events) == 3
-      assert pluck(received_events, :correlation_id) == pluck(remaining_events, :correlation_id)
-      assert pluck(received_events, :data) == pluck(remaining_events, :data)
+      [subscription: subscription]
     end
+  end
+
+  test "should not notify events until ack received" do
+    events = EventFactory.create_recorded_events(6, 1)
+    initial_events = Enum.take(events, 3)
+    remaining_events = Enum.drop(events, 3)
+
+    subscription =
+      create_subscription()
+      |> StreamSubscription.catch_up(fn last_seen -> last_seen end)
+      |> StreamSubscription.caught_up(0)
+      |> StreamSubscription.notify_events(initial_events)
+      |> StreamSubscription.notify_events(remaining_events)
+
+    assert subscription.state == :subscribed
+
+    # only receive initial events
+    assert_receive {:events, received_events, nil}
+    refute_receive {:events, _received_events, nil}
+
+    assert length(received_events) == 3
+    assert pluck(received_events, :correlation_id) == pluck(initial_events, :correlation_id)
+    assert pluck(received_events, :data) == pluck(initial_events, :data)
+
+    # don't receive remaining events until ack received for all initial events
+    subscription = ack_refute_receive(subscription, 1)
+    subscription = ack_refute_receive(subscription, 2)
+
+    subscription =
+      subscription
+      |> StreamSubscription.ack(3)
+
+    assert subscription.state == :subscribed
+
+    # now receive all remaining events
+    assert_receive {:events, received_events, nil}
+
+    assert length(received_events) == 3
+    assert pluck(received_events, :correlation_id) == pluck(remaining_events, :correlation_id)
+    assert pluck(received_events, :data) == pluck(remaining_events, :data)
   end
 
   describe "pending event buffer limit" do
@@ -194,7 +220,8 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
 
       subscription =
         create_subscription(max_size: 3)
-        |> StreamSubscription.catch_up
+        |> StreamSubscription.catch_up(fn last_seen -> last_seen end)
+        |> StreamSubscription.caught_up(0)
         |> StreamSubscription.notify_events(initial_events)
         |> StreamSubscription.notify_events(remaining_events)
 
@@ -207,11 +234,9 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
       assert pluck(received_events, :correlation_id) == pluck(initial_events, :correlation_id)
       assert pluck(received_events, :data) == pluck(initial_events, :data)
 
-      subscription =
-        subscription
-        |> StreamSubscription.ack(3)
+      subscription = StreamSubscription.ack(subscription, 3)
 
-      assert subscription.state == :catching_up
+      assert subscription.state == :request_catch_up
 
       # now receive all remaining events
       assert_receive {:events, received_events, nil}
@@ -228,15 +253,14 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
 
       subscription =
         create_subscription(max_size: 3)
-        |> StreamSubscription.catch_up
+        |> StreamSubscription.catch_up(fn last_seen -> last_seen end)
+        |> StreamSubscription.caught_up(0)
         |> StreamSubscription.notify_events(initial_events)
         |> StreamSubscription.notify_events(remaining_events)
 
       assert subscription.state == :max_capacity
 
-      subscription =
-        subscription
-        |> StreamSubscription.ack(1)
+      subscription = StreamSubscription.ack(subscription, 1)
 
       assert subscription.state == :max_capacity
 
@@ -245,17 +269,13 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
 
       assert length(received_events) == 3
 
-      subscription =
-        subscription
-        |> StreamSubscription.ack(2)
+      subscription = StreamSubscription.ack(subscription, 2)
 
       assert subscription.state == :max_capacity
 
-      subscription =
-        subscription
-        |> StreamSubscription.ack(3)
+      subscription = StreamSubscription.ack(subscription, 3)
 
-      assert subscription.state == :catching_up
+      assert subscription.state == :request_catch_up
 
       # now receive all remaining events
       assert_receive {:events, received_events, nil}
@@ -272,9 +292,7 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
   end
 
   defp ack_refute_receive(subscription, ack) do
-    subscription =
-      subscription
-      |> StreamSubscription.ack(ack)
+    subscription = StreamSubscription.ack(subscription, ack)
 
     assert subscription.state == :subscribed
     assert subscription.data.last_seen == 6

--- a/test/subscriptions/single_stream_subscription_test.exs
+++ b/test/subscriptions/single_stream_subscription_test.exs
@@ -21,7 +21,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
 
     subscription = create_subscription(stream_uuid, stream)
 
-    assert subscription.state == :catching_up
+    assert subscription.state == :request_catch_up
     assert subscription.data.subscription_name == @subscription_name
     assert subscription.data.subscriber == self()
     assert subscription.data.last_seen == 0
@@ -34,48 +34,87 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
 
     subscription = create_subscription(stream_uuid, stream, start_from_stream_version: 2)
 
-    assert subscription.state == :catching_up
+    assert subscription.state == :request_catch_up
     assert subscription.data.subscription_name == @subscription_name
     assert subscription.data.subscriber == self()
     assert subscription.data.last_seen == 2
     assert subscription.data.last_ack == 2
   end
 
-  test "catch-up subscription, no persisted events" do
-    stream_uuid = UUID.uuid4
-    {:ok, stream} = Streams.open_stream(stream_uuid)
+  describe "catch-up subscription" do
+    test "catch-up subscription, no persisted events" do
+      self = self()
+      stream_uuid = UUID.uuid4
+      {:ok, stream} = Streams.open_stream(stream_uuid)
 
-    subscription =
-      create_subscription(stream_uuid, stream)
-      |> StreamSubscription.catch_up
+      subscription =
+        stream_uuid
+        |> create_subscription(stream)
+        |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
 
-    assert subscription.state == :subscribed
-    assert subscription.data.last_seen == 0
-  end
+      assert subscription.state == :catching_up
+      assert subscription.data.last_seen == 0
 
-  test "catch-up subscription, unseen persisted events", %{conn: conn} do
-    stream_uuid = UUID.uuid4
-    {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
-    recorded_events = EventFactory.create_recorded_events(3, stream_id)
-    {:ok, 3} = Appender.append(conn, stream_id, recorded_events)
+      assert_receive {:caught_up, 0}
+    end
 
-    {:ok, stream} = Streams.open_stream(stream_uuid)
+    test "catch-up subscription, unseen persisted events", %{conn: conn} do
+      self = self()
+      stream_uuid = UUID.uuid4
+      {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
+      recorded_events = EventFactory.create_recorded_events(3, stream_id)
+      {:ok, 3} = Appender.append(conn, stream_id, recorded_events)
 
-    subscription =
-      create_subscription(stream_uuid, stream)
-      |> StreamSubscription.catch_up
+      {:ok, stream} = Streams.open_stream(stream_uuid)
 
-    assert subscription.state == :subscribed
-    assert subscription.data.last_seen == 3
+      subscription =
+        stream_uuid
+        |> create_subscription(stream)
+        |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
 
-    assert_receive {:events, received_events, nil}
-    expected_events = EventFactory.deserialize_events(recorded_events)
+      assert subscription.state == :catching_up
+      assert subscription.data.last_seen == 0
 
-    assert pluck(received_events, :correlation_id) == pluck(expected_events, :correlation_id)
-    assert pluck(received_events, :data) == pluck(expected_events, :data)
+      assert_receive {:events, received_events, ^self}
+      assert_receive {:caught_up, 3}
+
+      expected_events = EventFactory.deserialize_events(recorded_events)
+
+      assert pluck(received_events, :correlation_id) == pluck(expected_events, :correlation_id)
+      assert pluck(received_events, :data) == pluck(expected_events, :data)
+    end
+
+    test "confirm subscription caught up to persisted events", %{conn: conn} do
+      self = self()
+      stream_uuid = UUID.uuid4
+      {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
+      recorded_events = EventFactory.create_recorded_events(3, stream_id)
+      {:ok, 3} = Appender.append(conn, stream_id, recorded_events)
+
+      {:ok, stream} = Streams.open_stream(stream_uuid)
+
+      subscription =
+        stream_uuid
+        |> create_subscription(stream)
+        |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
+
+      assert subscription.state == :catching_up
+      assert subscription.data.last_seen == 0
+
+      assert_receive {:caught_up, last_seen}
+
+      subscription =
+        subscription
+        |> StreamSubscription.caught_up(last_seen)
+
+      assert subscription.state == :subscribed
+      assert subscription.data.last_seen == 3
+      assert subscription.data.last_ack == 0
+    end
   end
 
   test "notify events" do
+    self = self()
     stream_uuid = UUID.uuid4
     {:ok, stream} = Streams.open_stream(stream_uuid)
 
@@ -83,85 +122,128 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
 
     subscription =
       create_subscription(stream_uuid, stream)
-      |> StreamSubscription.catch_up
+      |> StreamSubscription.catch_up(fn last_seen -> last_seen end)
+      |> StreamSubscription.caught_up(0)
       |> StreamSubscription.notify_events(events)
 
     assert subscription.state == :subscribed
 
-    assert_receive {:events, received_events, nil}
+    assert_receive {:events, received_events, ^self}
 
     assert pluck(received_events, :correlation_id) == pluck(events, :correlation_id)
     assert pluck(received_events, :data) == pluck(events, :data)
   end
 
-  test "ack notified events", %{conn: conn} do
-    stream_uuid = UUID.uuid4
-    {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
-    {:ok, 3} = Appender.append(conn, stream_id, EventFactory.create_recorded_events(3, stream_id))
+  describe "ack events" do
+    setup [:create_stream, :create_subscription]
 
-    {:ok, stream} = Streams.open_stream(stream_uuid)
+    test "ack notified events", %{stream_uuid: stream_uuid, stream: stream} do
+      self = self()
 
-    subscription =
-      create_subscription(stream_uuid, stream)
-      |> StreamSubscription.catch_up
+      subscription =
+        stream_uuid
+        |> create_subscription(stream)
+        |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
 
-    assert subscription.state == :subscribed
+      assert subscription.state == :catching_up
 
-    assert_receive {:events, received_events, nil}
-    assert length(received_events) == 3
+      assert_receive {:caught_up, last_seen}
 
-    subscription =
-      subscription
-      |> StreamSubscription.ack(3)
+      subscription = StreamSubscription.caught_up(subscription, last_seen)
 
-    assert subscription.state == :subscribed
-    assert subscription.data.last_seen == 3
-    assert subscription.data.last_ack == 3
+      assert subscription.state == :subscribed
 
-    subscription =
-      create_subscription(stream_uuid, stream)
-      |> StreamSubscription.catch_up
+      assert_receive {:events, received_events, ^self}
+      assert length(received_events) == 3
 
-    # should not receive already seen events
-    refute_receive {:events, _received_events, nil}
+      subscription =
+        subscription
+        |> StreamSubscription.ack(3)
 
-    assert subscription.state == :subscribed
-    assert subscription.data.last_seen == 3
-    assert subscription.data.last_ack == 3
+      assert subscription.state == :subscribed
+      assert subscription.data.last_seen == 3
+      assert subscription.data.last_ack == 3
+
+      # create subscription with no unseen events
+      subscription =
+        stream_uuid
+        |> create_subscription(stream)
+        |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
+
+      assert subscription.state == :catching_up
+
+      assert_receive {:caught_up, last_seen}
+
+      # should not receive already seen events
+      refute_receive {:events, _received_events, ^self}
+
+      subscription = StreamSubscription.caught_up(subscription, last_seen)
+
+      assert subscription.state == :subscribed
+      assert subscription.data.last_seen == 3
+      assert subscription.data.last_ack == 3
+    end
+
+    test "should replay events when not acknowledged", %{stream_uuid: stream_uuid, stream: stream} do
+      self = self()
+
+      subscription =
+        stream_uuid
+        |> create_subscription(stream)
+        |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
+
+      assert subscription.state == :catching_up
+
+      # should receive already seen, but not ack'd, events
+      assert_receive {:events, received_events, ^self}
+      assert length(received_events) == 3
+
+      assert_receive {:caught_up, last_seen}
+
+      subscription = StreamSubscription.caught_up(subscription, last_seen)
+
+      assert subscription.state == :subscribed
+      assert subscription.data.last_seen == 3
+      assert subscription.data.last_ack == 0
+    end
   end
 
-  test "should replay events when not acknowledged", %{conn: conn} do
+  defp create_stream(%{conn: conn}) do
     stream_uuid = UUID.uuid4
     {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
     {:ok, 3} = Appender.append(conn, stream_id, EventFactory.create_recorded_events(3, stream_id))
 
     {:ok, stream} = Streams.open_stream(stream_uuid)
 
+    [stream_uuid: stream_uuid, stream: stream]
+  end
+
+  defp create_subscription(%{stream_uuid: stream_uuid, stream: stream}) do
+    self = self()
+
     subscription =
-      create_subscription(stream_uuid, stream)
-      |> StreamSubscription.catch_up
+      stream_uuid
+      |> create_subscription(stream)
+      |> StreamSubscription.catch_up(fn last_seen -> send(self, {:caught_up, last_seen}) end)
+
+    assert subscription.state == :catching_up
+
+    assert_receive {:events, received_events, ^self}
+    assert length(received_events) == 3
+
+    assert_receive {:caught_up, 3}
+
+    subscription = StreamSubscription.caught_up(subscription, 3)
 
     assert subscription.state == :subscribed
     assert subscription.data.last_seen == 3
     assert subscription.data.last_ack == 0
 
-    assert_receive {:events, received_events, nil}
-    assert length(received_events) == 3
-
-    subscription =
-      create_subscription(stream_uuid, stream)
-      |> StreamSubscription.catch_up
-
-    # should receive already seen events
-    assert_receive {:events, received_events, nil}
-    assert length(received_events) == 3
-
-    assert subscription.state == :subscribed
-    assert subscription.data.last_seen == 3
-    assert subscription.data.last_ack == 0
+    [subscription: subscription]
   end
 
   test "should not notify events until ack received" do
+    self = self()
     stream_uuid = UUID.uuid4
     events = EventFactory.create_recorded_events(6, 1)
     initial_events = Enum.take(events, 3)
@@ -170,8 +252,10 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     {:ok, stream} = Streams.open_stream(stream_uuid)
 
     subscription =
-      create_subscription(stream_uuid, stream)
-      |> StreamSubscription.catch_up
+      stream_uuid
+      |> create_subscription(stream)
+      |> StreamSubscription.catch_up(fn last_seen -> last_seen end)
+      |> StreamSubscription.caught_up(0)
       |> StreamSubscription.notify_events(initial_events)
       |> StreamSubscription.notify_events(remaining_events)
 
@@ -179,8 +263,8 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     assert subscription.data.last_ack == 0
 
     # only receive initial events
-    assert_receive {:events, received_events, nil}
-    refute_receive {:events, _received_events, nil}
+    assert_receive {:events, received_events, ^self}
+    refute_receive {:events, _received_events, ^self}
 
     assert length(received_events) == 3
     assert pluck(received_events, :correlation_id) == pluck(initial_events, :correlation_id)
@@ -195,7 +279,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     assert subscription.data.last_ack == 3
 
    # now receive all remaining events
-   assert_receive {:events, received_events, nil}
+   assert_receive {:events, received_events, ^self}
 
    assert length(received_events) == 3
    assert pluck(received_events, :correlation_id) == pluck(remaining_events, :correlation_id)
@@ -204,7 +288,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
 
   defp create_subscription(stream_uuid, stream, opts \\ []) do
     StreamSubscription.new
-    |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, nil, self(), opts)
+    |> StreamSubscription.subscribe(stream_uuid, stream, @subscription_name, self(), self(), opts)
   end
 
   defp pluck(enumerable, field) do

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -247,7 +247,6 @@ defmodule EventStore.Subscriptions.SubscribeToStream do
       assert pluck(Subscriber.received_events(subscriber2), :data) == pluck(events, :data)
     end
 
-    @tag :wip
     test "should monitor subscriber and terminate subscription on error", %{subscription_name: subscription_name} do
       stream_uuid = UUID.uuid4
       events = EventFactory.create_events(1)

--- a/test/subscriptions/subscribe_to_stream_test.exs
+++ b/test/subscriptions/subscribe_to_stream_test.exs
@@ -247,6 +247,7 @@ defmodule EventStore.Subscriptions.SubscribeToStream do
       assert pluck(Subscriber.received_events(subscriber2), :data) == pluck(events, :data)
     end
 
+    @tag :wip
     test "should monitor subscriber and terminate subscription on error", %{subscription_name: subscription_name} do
       stream_uuid = UUID.uuid4
       events = EventFactory.create_events(1)


### PR DESCRIPTION
Add support to stream events from a single event store stream.

Subscriptions now use Elixir streams to read events from database when catching up. 

This eliminates contention on a single stream, or all streams, process when many subscriptions are attempting to catch-up. 