### PR TITLE
Writer not parsing url from config

### DIFF
--- a/lib/event_store/writer.ex
+++ b/lib/event_store/writer.ex
@@ -16,7 +16,9 @@ defmodule EventStore.Writer do
   end
 
   def init(%Writer{} = state) do
-    storage_config = Application.get_env(:eventstore, EventStore.Storage)
+    storage_config =
+      Application.get_env(:eventstore, EventStore.Storage)
+      |> EventStore.Config.parse()
 
     {:ok, conn} = Postgrex.start_link(storage_config)
 


### PR DESCRIPTION
The poolboy config is parsing the url and extracting host etc. The writer must do so as well.