### PR TITLE
allow url to be a system variable

### DIFF
--- a/lib/event_store/config.ex
+++ b/lib/event_store/config.ex
@@ -1,5 +1,5 @@
 defmodule EventStore.Config do
-  
+
   @doc """
   Normalizes the application configuration.
   """
@@ -12,6 +12,9 @@ defmodule EventStore.Config do
   Converts a database url into a Keyword list
   """
   def parse_url(""), do: []
+  def parse_url({:system, env}) when is_binary(env) do
+    parse_url(System.get_env(env) || "")
+  end
   def parse_url(url) do
     info = url |> URI.decode() |> URI.parse()
 

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -26,4 +26,19 @@ defmodule EventStore.ConfigTest do
       hostname: "localhost"
     ]
   end
+
+  test "dynamically fetch url" do
+    System.put_env("SOME_ENV_VAR", "postgres://username:password@localhost/database")
+    on_exit(fn -> System.delete_env("SOME_ENV_VAR") end)
+
+    config = Config.parse([ url: {:system, "SOME_ENV_VAR"} ])
+
+    assert config == [
+      username: "username",
+      password: "password",
+      database: "database",
+      hostname: "localhost"
+    ]
+  end
+
 end


### PR DESCRIPTION
This follows the Ecto convention of allowing a {:system, "SOME_VAR"} tuple to fetch the url from the environment at runtime.