### PR TITLE
Add Streams.close_stream function.

### DIFF
--- a/lib/event_store/streams/supervisor.ex
+++ b/lib/event_store/streams/supervisor.ex
@@ -13,6 +13,10 @@ defmodule EventStore.Streams.Supervisor do
     Supervisor.start_child(supervisor, [stream_uuid])
   end
 
+  def stop_stream(supervisor, stream) do
+    Supervisor.terminate_child(supervisor, stream)
+  end
+
   def init(serializer) do
     children = [
       worker(EventStore.Streams.Stream, [serializer], restart: :temporary),


### PR DESCRIPTION
Functions `append_to_stream`, `stream_forward`, `read_stream_forward` open a stream but never close it, so it occupy memory for process.

Closing stream function gives me the ability to create event_handler in commanded and manually close streams which no longer will be accessed. 

It's fragile because if where are will be a subscriber, it wakes up stream, and no one stops it after subscriber unsubscribes. But for me, it's rare to use single_subscriber.