### PR TITLE
Catch-up subscription waits for subscriber ack

### DIFF
--- a/bench/storage/subscribe_to_stream_bench.exs
+++ b/bench/storage/subscribe_to_stream_bench.exs
@@ -25,7 +25,6 @@ defmodule SubscribeToStreamBench do
 
   defp subscribe_to_stream(events, concurrency) do
     stream_uuid = UUID.uuid4()
-    events = EventFactory.create_events(100)
 
     tasks = Enum.map(1..concurrency, fn index ->
       Task.async fn ->

--- a/lib/event_store/storage/appender.ex
+++ b/lib/event_store/storage/appender.ex
@@ -57,7 +57,7 @@ defmodule EventStore.Storage.Appender do
     {:error, :failed_to_append_events}
   end
 
-  defp handle_response({:ok, %Postgrex.Result{num_rows: num_rows, rows: rows}} = result, events) do
+  defp handle_response({:ok, %Postgrex.Result{num_rows: num_rows, rows: rows}}, events) do
     event_ids = List.flatten(rows)
 
     _ = Logger.info(fn -> "appended #{num_rows} event(s) to stream id #{stream_id(events)} (event ids: #{Enum.join(event_ids, ", ")})" end)

--- a/lib/event_store/subscriptions/subscription.ex
+++ b/lib/event_store/subscriptions/subscription.ex
@@ -51,6 +51,10 @@ defmodule EventStore.Subscriptions.Subscription do
     GenServer.cast(subscription, {:ack, event_id})
   end
 
+  def caught_up(subscription, last_seen) do
+    GenServer.cast(subscription, {:caught_up, last_seen})
+  end
+
   def unsubscribe(subscription) do
     GenServer.call(subscription, {:unsubscribe})
   end
@@ -86,12 +90,7 @@ defmodule EventStore.Subscriptions.Subscription do
   end
 
   def handle_cast({:catch_up}, %Subscription{subscription: subscription} = state) do
-    reply_to = self()
-
-    subscription = StreamSubscription.catch_up(subscription, fn last_seen ->
-      # notify subscription caught up to given last seen event
-      GenServer.cast(reply_to, {:caught_up, last_seen})
-    end)
+    subscription = StreamSubscription.catch_up(subscription)
 
     state = %Subscription{state | subscription: subscription}
 

--- a/lib/event_store/subscriptions/subscription_state.ex
+++ b/lib/event_store/subscriptions/subscription_state.ex
@@ -1,5 +1,6 @@
 defmodule EventStore.Subscriptions.SubscriptionState do
   defstruct [
+    catch_up_pid: nil,
     stream_uuid: nil,
     subscription_name: nil,
     subscriber: nil,

--- a/test/publish_events_test.exs
+++ b/test/publish_events_test.exs
@@ -2,7 +2,9 @@ defmodule EventStore.PublishEventsTest do
   use EventStore.StorageCase
 
   alias EventStore.{EventFactory,Publisher,Subscriptions,Subscriber,Wait}
+  alias EventStore.ProcessHelper
   alias EventStore.Subscriptions.Subscription
+  alias EventStore.Streams.Stream
 
   @all_stream "$all"
   @subscription_name "test_subscription"
@@ -16,12 +18,7 @@ defmodule EventStore.PublishEventsTest do
     stream2_events = EventFactory.create_recorded_events(1, stream2_uuid, 2)
     stream3_events = EventFactory.create_recorded_events(1, stream3_uuid, 3)
 
-    {:ok, subscriber} = Subscriber.start_link(self())
-    {:ok, subscription} = Subscriptions.subscribe_to_stream(@all_stream, @subscription_name, subscriber, start_from: :current)
-
-    Wait.until(fn ->
-      assert Registry.lookup(EventStore.Subscriptions.PubSub, @all_stream) !== []
-    end)
+    {:ok, subscriber, subscription} = subscribe_to_all_streams(start_from_event_id: 0)
 
     # notify stream2 events before stream3 and stream1 (out of order)
     Publisher.notify_events(stream2_uuid, stream2_events)
@@ -43,5 +40,44 @@ defmodule EventStore.PublishEventsTest do
     assert stream3_received_events == EventFactory.deserialize_events(stream3_events)
 
     assert Subscriber.received_events(subscriber) == EventFactory.deserialize_events(stream1_events ++ stream2_events ++ stream3_events)
+  end
+
+  test "should resume publishing on restart" do
+    stream1_uuid = UUID.uuid4()
+    stream1_events = EventFactory.create_events(1)
+
+    :ok = EventStore.append_to_stream(stream1_uuid, 0, stream1_events)
+
+    {:ok, subscriber, subscription} = subscribe_to_all_streams(start_from_event_id: 1)
+
+    restart_publisher()
+
+    stream2_uuid = UUID.uuid4()
+    stream2_events = EventFactory.create_recorded_events(1, stream2_uuid, 2)
+
+    Publisher.notify_events(stream2_uuid, stream2_events)
+
+    # should receive published events
+    assert_receive {:events, stream2_received_events}
+    assert stream2_received_events == EventFactory.deserialize_events(stream2_events)
+  end
+
+  defp subscribe_to_all_streams(opts) do
+    {:ok, subscriber} = Subscriber.start_link(self())
+    {:ok, subscription} = Subscriptions.subscribe_to_stream(@all_stream, @subscription_name, subscriber, opts)
+
+    Wait.until(fn ->
+      assert Registry.lookup(EventStore.Subscriptions.PubSub, @all_stream) !== []
+    end)
+
+    {:ok, subscriber, subscription}
+  end
+
+  defp restart_publisher do
+    ProcessHelper.shutdown(Publisher)
+
+    Wait.until(fn ->
+      assert Process.whereis(Publisher) != nil
+    end)
   end
 end

--- a/test/support/process_helper.ex
+++ b/test/support/process_helper.ex
@@ -4,7 +4,11 @@ defmodule EventStore.ProcessHelper do
   @doc """
   Stop the given process with a non-normal exit reason
   """
-  def shutdown(pid) do
+  def shutdown(name) when is_atom(name) do
+    name |> Process.whereis() |> shutdown()
+  end
+
+  def shutdown(pid) when is_pid(pid) do
     Process.unlink(pid)
     Process.exit(pid, :shutdown)
 


### PR DESCRIPTION
During event replay while a subscription is catching up, the event stream should wait for each chunk of events to be `ack`d before continuing.