### PR TITLE
Stream version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Support for running on a cluster of nodes using [Swarm](https://hex.pm/packages/swarm) for process distribution ([#53](https://github.com/slashdotdash/eventstore/issues/53)).
 
+- Add `stream_version` column to `streams` table. It is used for stream info querying and optimistic concurrency checks, instead of querying the `events` table.
+
+### Upgrading
+
+Run the schema migration [v0.11.0.sql](scripts/upgrades/v0.11.0.sql) script against your event store database.
+
 ## v0.10.0
 
 ### Enhancements

--- a/scripts/upgrades/v0.10.0.sql
+++ b/scripts/upgrades/v0.10.0.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-  -- create new `schema_migrations` table
-  CREATE TABLE schema_migrations
+  -- create `schema_migrations` table
+  CREATE TABLE IF NOT EXISTS schema_migrations
   (
       major_version int NOT NULL,
       minor_version int NOT NULL,

--- a/scripts/upgrades/v0.11.0.sql
+++ b/scripts/upgrades/v0.11.0.sql
@@ -1,0 +1,19 @@
+BEGIN;
+  -- record schema migration
+  INSERT INTO schema_migrations (major_version, minor_version, patch_version) VALUES (0, 11, 0);
+
+  ALTER TABLE streams ADD COLUMN stream_version bigint DEFAULT 0;
+
+  UPDATE streams s
+  SET stream_version = (
+    SELECT COALESCE(e.stream_version, 0)
+    FROM events e
+    WHERE e.stream_id = s.stream_id
+    ORDER BY e.stream_version DESC
+    LIMIT 1
+  );
+
+  -- enforce `stream_version` is not NULL
+  ALTER TABLE streams ALTER COLUMN stream_version SET NOT NULL;
+
+COMMIT;

--- a/scripts/upgrades/v0.11.0.sql
+++ b/scripts/upgrades/v0.11.0.sql
@@ -1,9 +1,21 @@
 BEGIN;
+
+  CREATE TABLE IF NOT EXISTS schema_migrations
+  (
+      major_version int NOT NULL,
+      minor_version int NOT NULL,
+      patch_version int NOT NULL,
+      migrated_at timestamp without time zone default (now() at time zone 'UTC') NOT NULL,
+      PRIMARY KEY(major_version, minor_version, patch_version)
+  );
+
   -- record schema migration
   INSERT INTO schema_migrations (major_version, minor_version, patch_version) VALUES (0, 11, 0);
 
+  -- add `stream_version` column to `streams` table
   ALTER TABLE streams ADD COLUMN stream_version bigint DEFAULT 0;
 
+  -- seed `stream_version` from `events` table for existing streams
   UPDATE streams s
   SET stream_version = (
     SELECT COALESCE(e.stream_version, 0)

--- a/scripts/upgrades/v0.9.0.sql
+++ b/scripts/upgrades/v0.9.0.sql
@@ -1,5 +1,19 @@
 BEGIN;
 
+  -- create `schema_migrations` table
+  CREATE TABLE IF NOT EXISTS schema_migrations
+  (
+      major_version int NOT NULL,
+      minor_version int NOT NULL,
+      patch_version int NOT NULL,
+      migrated_at timestamp without time zone default (now() at time zone 'UTC') NOT NULL,
+      PRIMARY KEY(major_version, minor_version, patch_version)
+  );
+
+  -- record schema migration
+  INSERT INTO schema_migrations (major_version, minor_version, patch_version) VALUES (0, 9, 0);
+
+  --- add `causation_id` to `events` table
   ALTER TABLE events ADD causation_id text;
 
 COMMIT;


### PR DESCRIPTION
Add `stream_version` column to `streams` table. 

It is used for stream info querying and optimistic concurrency checks, instead of querying the `events` table.