### PR TITLE
Fix for ack of last seen event in stream subscription

### DIFF
--- a/lib/event_store/subscriptions/stream_subscription.ex
+++ b/lib/event_store/subscriptions/stream_subscription.ex
@@ -243,7 +243,7 @@ defmodule EventStore.Subscriptions.StreamSubscription do
             |> Stream.chunk_by(&(&1.stream_id))
             |> Stream.each(fn events ->
               notify_subscriber(data, events)
-              wait_for_ack(events)
+              wait_for_ack(stream_uuid, events)
             end)
             |> Stream.map(&Enum.at(&1, -1))
             |> Enum.at(-1)
@@ -262,8 +262,8 @@ defmodule EventStore.Subscriptions.StreamSubscription do
   end
 
   # wait until the subscriber ack's the last sent event
-  defp wait_for_ack(events) when is_list(events) do
-    expected_event_id = List.last(events).event_id
+  defp wait_for_ack(stream_uuid, events) when is_list(events) do
+    expected_event_id = subscription_provider(stream_uuid).event_id(List.last(events))
 
     wait_for_ack_event_id(expected_event_id)
   end


### PR DESCRIPTION
Fix ack of last seen event where it should be dependent on the subscription provider instead of always taking event_id