### PR TITLE
Add :serializer to Getting Started config

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -14,6 +14,7 @@ EventStore is [available in Hex](https://hex.pm/packages/eventstore) and can be 
 
       ```elixir
       config :eventstore, EventStore.Storage,
+        serializer: EventStore.TermSerializer,
         username: "postgres",
         password: "postgres",
         database: "eventstore_dev",


### PR DESCRIPTION
This avoids an error on application start, which I got right after following the guide step by step:

```
** (Mix) Could not start application eventstore: exited in: EventStore.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (ArgumentError) EventStore storage configuration expects :serializer to be configured in environment
            (eventstore) lib/event_store.ex:229: EventStore.configured_serializer/0
            (eventstore) lib/event_store/supervisor.ex:5: EventStore.Supervisor.start_link/1
            (kernel) application_master.erl:273: :application_master.start_it_old/4
```