### PR TITLE
Include `stream_uuid` in `EventStore.RecordedEvent`

### DIFF
--- a/lib/event_store/recorded_event.ex
+++ b/lib/event_store/recorded_event.ex
@@ -1,15 +1,27 @@
 defmodule EventStore.RecordedEvent do
   @moduledoc """
-  RecordedEvent contains the persisted data and metadata for a single event.
+  `EventStore.RecordedEvent` contains the persisted data and metadata for a single event.
 
   Events are immutable once recorded.
+
+  ## Recorded event fields
+
+    - `event_id` - a globally unique, monotonically incrementing and gapless integer
+    - `stream_uuid` - the stream identity for the event
+    - `stream_version` - the version of the stream for the event
+    - `correlation_id` - an optional identifier used to correlate related messages
+    - `causation_id` - an optional identifier used to identify which message you are responding to
+    - `data` - the serialized event as binary data
+    - `metadata` - the serialized event metadata as binary data
+    - `created_at` - the date/time, in UTC, indicating when the event was persisted to storage
+
   """
 
   alias EventStore.RecordedEvent
-  
+
   @type t :: %RecordedEvent{
     event_id: non_neg_integer,
-    stream_id: non_neg_integer,
+    stream_uuid: String.t,
     stream_version: non_neg_integer,
     correlation_id: String.t,
     causation_id: String.t,
@@ -21,7 +33,7 @@ defmodule EventStore.RecordedEvent do
 
   defstruct [
     event_id: nil,
-    stream_id: nil,
+    stream_uuid: nil,
     stream_version: nil,
     correlation_id: nil,
     causation_id: nil,

--- a/lib/event_store/recorded_event.ex
+++ b/lib/event_store/recorded_event.ex
@@ -13,7 +13,7 @@ defmodule EventStore.RecordedEvent do
     - `causation_id` - an optional identifier used to identify which message you are responding to
     - `data` - the serialized event as binary data
     - `metadata` - the serialized event metadata as binary data
-    - `created_at` - the date/time, in UTC, indicating when the event was persisted to storage
+    - `created_at` - the date/time, in UTC, indicating when the event was created
 
   """
 

--- a/lib/event_store/registration/distributed_registry.ex
+++ b/lib/event_store/registration/distributed_registry.ex
@@ -1,3 +1,4 @@
+if Code.ensure_loaded?(Swarm) do
 defmodule EventStore.Registration.DistributedRegistry do
   @moduledoc """
   Process registration and distribution throughout a cluster of nodes using [Swarm](https://github.com/bitwalker/swarm)
@@ -88,4 +89,5 @@ defmodule EventStore.Registration.DistributedRegistry do
   defp publish_events_to_node(node, stream_uuid, events) do
     Publisher.notify_events({Publisher, node}, stream_uuid, events)
   end
+end
 end

--- a/lib/event_store/sql/statements.ex
+++ b/lib/event_store/sql/statements.ex
@@ -356,18 +356,19 @@ WHERE source_uuid = $1;
   def read_events_forward do
 """
 SELECT
-  event_id,
-  stream_id,
-  stream_version,
-  event_type,
-  correlation_id,
-  causation_id,
-  data,
-  metadata,
-  created_at
-FROM events
-WHERE stream_id = $1 and stream_version >= $2
-ORDER BY stream_version ASC
+  e.event_id,
+  s.stream_uuid,
+  e.stream_version,
+  e.event_type,
+  e.correlation_id,
+  e.causation_id,
+  e.data,
+  e.metadata,
+  e.created_at
+FROM events e
+INNER JOIN streams s ON s.stream_id = e.stream_id
+WHERE e.stream_id = $1 and e.stream_version >= $2
+ORDER BY e.stream_version ASC
 LIMIT $3;
 """
   end
@@ -375,18 +376,19 @@ LIMIT $3;
   def read_all_events_forward do
 """
 SELECT
-  event_id,
-  stream_id,
-  stream_version,
-  event_type,
-  correlation_id,
-  causation_id,
-  data,
-  metadata,
-  created_at
-FROM events
-WHERE event_id >= $1
-ORDER BY event_id ASC
+  e.event_id,
+  s.stream_uuid,
+  e.stream_version,
+  e.event_type,
+  e.correlation_id,
+  e.causation_id,
+  e.data,
+  e.metadata,
+  e.created_at
+FROM events e
+INNER JOIN streams s ON s.stream_id = e.stream_id
+WHERE e.event_id >= $1
+ORDER BY e.event_id ASC
 LIMIT $2;
 """
   end

--- a/lib/event_store/storage.ex
+++ b/lib/event_store/storage.ex
@@ -38,8 +38,8 @@ defmodule EventStore.Storage do
   @doc """
   Append the given list of recorded events to storage
   """
-  def append_to_stream(events) do
-    Appender.append(@event_store, events)
+  def append_to_stream(stream_id, events) do
+    Appender.append(@event_store, stream_id, events)
   end
 
   @doc """

--- a/lib/event_store/storage/reader.ex
+++ b/lib/event_store/storage/reader.ex
@@ -55,10 +55,10 @@ defmodule EventStore.Storage.Reader do
       |> Enum.map(&to_event_data_from_row/1)
     end
 
-    def to_event_data_from_row([event_id, stream_id, stream_version, event_type, correlation_id, causation_id, data, metadata, created_at]) do
+    def to_event_data_from_row([event_id, stream_uuid, stream_version, event_type, correlation_id, causation_id, data, metadata, created_at]) do
       %RecordedEvent{
         event_id: event_id,
-        stream_id: stream_id,
+        stream_uuid: stream_uuid,
         stream_version: stream_version,
         event_type: event_type,
         correlation_id: correlation_id,

--- a/lib/event_store/streams/stream.ex
+++ b/lib/event_store/streams/stream.ex
@@ -138,7 +138,7 @@ defmodule EventStore.Streams.Stream do
 
   defp append_to_storage(_expected_version, _events, _state), do: {:error, :wrong_expected_version}
 
-  defp prepare_events(events, %Stream{serializer: serializer, stream_id: stream_id, stream_version: stream_version}) do
+  defp prepare_events(events, %Stream{serializer: serializer, stream_version: stream_version}) do
     initial_stream_version = stream_version + 1
 
     events
@@ -146,7 +146,6 @@ defmodule EventStore.Streams.Stream do
     |> Enum.with_index(0)
     |> Enum.map(fn {recorded_event, index} ->
       %RecordedEvent{recorded_event |
-        stream_id: stream_id,
         stream_version: initial_stream_version + index
       }
     end)
@@ -168,8 +167,8 @@ defmodule EventStore.Streams.Stream do
     DateTime.utc_now |> DateTime.to_naive
   end
 
-  defp write_to_stream(prepared_events, %Stream{stream_uuid: stream_uuid}) do
-    Writer.append_to_stream(prepared_events, stream_uuid)
+  defp write_to_stream(prepared_events, %Stream{stream_id: stream_id, stream_uuid: stream_uuid}) do
+    Writer.append_to_stream(prepared_events, stream_id, stream_uuid)
   end
 
   defp read_storage_forward(stream_id, start_version, count, serializer) when not is_nil(stream_id) do

--- a/lib/event_store/streams/stream.ex
+++ b/lib/event_store/streams/stream.ex
@@ -138,15 +138,14 @@ defmodule EventStore.Streams.Stream do
 
   defp append_to_storage(_expected_version, _events, _state), do: {:error, :wrong_expected_version}
 
-  defp prepare_events(events, %Stream{serializer: serializer, stream_version: stream_version}) do
-    initial_stream_version = stream_version + 1
-
+  defp prepare_events(events, %Stream{serializer: serializer, stream_uuid: stream_uuid, stream_version: stream_version}) do
     events
     |> Enum.map(&map_to_recorded_event(&1, serializer))
-    |> Enum.with_index(0)
+    |> Enum.with_index(1)
     |> Enum.map(fn {recorded_event, index} ->
       %RecordedEvent{recorded_event |
-        stream_version: initial_stream_version + index
+        stream_uuid: stream_uuid,
+        stream_version: stream_version + index,
       }
     end)
   end

--- a/lib/event_store/subscriptions/stream_subscription.ex
+++ b/lib/event_store/subscriptions/stream_subscription.ex
@@ -338,7 +338,7 @@ defmodule EventStore.Subscriptions.StreamSubscription do
     end
   end
 
-  defp chunk_by(%RecordedEvent{stream_id: stream_id, correlation_id: correlation_id}), do: {stream_id, correlation_id}
+  defp chunk_by(%RecordedEvent{stream_uuid: stream_uuid, correlation_id: correlation_id}), do: {stream_uuid, correlation_id}
 
   defp notify_subscriber(%SubscriptionState{}, []), do: nil
   defp notify_subscriber(%SubscriptionState{subscriber: subscriber, mapper: mapper}, events) when is_function(mapper) do

--- a/lib/event_store/writer.ex
+++ b/lib/event_store/writer.ex
@@ -8,15 +8,14 @@ defmodule EventStore.Writer do
   }
 
   @doc """
-  Append the given list of recorded events to the stream
+  Append the given list of recorded events to the stream.
 
   Returns `:ok` on success, or `{:error, reason}` on failure
   """
-  @spec append_to_stream(list(RecordedEvent.t), String.t) :: :ok | {:error, reason :: any()}
-  def append_to_stream(events, stream_uuid)
-  def append_to_stream([], _stream_uuid), do: :ok
-  def append_to_stream(events, stream_uuid) do
-    case Storage.append_to_stream(events) do
+  @spec append_to_stream(events :: list(RecordedEvent.t), stream_id :: non_neg_integer(), stream_uuid :: String.t) :: :ok | {:error, reason :: any()}
+  def append_to_stream([], _stream_id, _stream_uuid), do: :ok
+  def append_to_stream(events, stream_id, stream_uuid) do
+    case Storage.append_to_stream(stream_id, events) do
       {:ok, assigned_event_ids} ->
         events
         |> assign_event_ids(assigned_event_ids)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule EventStore.Mixfile do
   use Mix.Project
 
-  @version "0.11.0-rc.0"
+  @version "0.11.0-rc.1"
 
   def project do
     [

--- a/test/event_store_test.exs
+++ b/test/event_store_test.exs
@@ -38,8 +38,9 @@ defmodule EventStoreTest do
     created_event = hd(events)
     recorded_event = hd(recorded_events)
 
+    assert is_integer(recorded_event.event_id)
     assert recorded_event.event_id > 0
-    assert recorded_event.stream_id > 0
+    assert recorded_event.stream_uuid == stream_uuid
     assert recorded_event.data == created_event.data
     assert recorded_event.metadata == created_event.metadata
   end
@@ -55,7 +56,7 @@ defmodule EventStoreTest do
     recorded_event = hd(recorded_events)
 
     assert recorded_event.event_id > 0
-    assert recorded_event.stream_id > 0
+    assert recorded_event.stream_uuid == stream_uuid
     assert recorded_event.data == created_event.data
     assert recorded_event.metadata == created_event.metadata
   end
@@ -71,7 +72,7 @@ defmodule EventStoreTest do
     recorded_event = hd(recorded_events)
 
     assert recorded_event.event_id > 0
-    assert recorded_event.stream_id > 0
+    assert recorded_event.stream_uuid == stream_uuid
     assert recorded_event.data == created_event.data
     assert recorded_event.metadata == created_event.metadata
   end
@@ -107,7 +108,7 @@ defmodule EventStoreTest do
     assert length(received_events) == 1
     assert hd(received_events).data == hd(new_events).data
 
-    :ok = EventStore.unsubscribe_from_all_streams(@subscription_name)    
+    :ok = EventStore.unsubscribe_from_all_streams(@subscription_name)
   end
 
   defmodule ExampleData, do: defstruct [:data]

--- a/test/storage/append_events_test.exs
+++ b/test/storage/append_events_test.exs
@@ -6,71 +6,79 @@ defmodule EventStore.Storage.AppendEventsTest do
   alias EventStore.Storage.{Appender,Stream}
 
   test "append single event to new stream", %{conn: conn} do
-    {:ok, stream_id} = Stream.create_stream(conn, UUID.uuid4)
-    recorded_events = EventFactory.create_recorded_events(1, stream_id)
+    {:ok, stream_uuid, stream_id} = create_stream(conn)
+    recorded_events = EventFactory.create_recorded_events(1, stream_uuid)
 
-    {:ok, [1]} = Appender.append(conn, recorded_events)
+    {:ok, [1]} = Appender.append(conn, stream_id, recorded_events)
   end
 
   test "append multiple events to new stream", %{conn: conn} do
-    {:ok, stream_id} = Stream.create_stream(conn, UUID.uuid4)
-    recorded_events = EventFactory.create_recorded_events(3, stream_id)
+    {:ok, stream_uuid, stream_id} = create_stream(conn)
+    recorded_events = EventFactory.create_recorded_events(3, stream_uuid)
 
-    {:ok, [1, 2, 3]} = Appender.append(conn, recorded_events)
+    {:ok, [1, 2, 3]} = Appender.append(conn, stream_id, recorded_events)
   end
 
   test "append single event to existing stream, in separate writes", %{conn: conn} do
-    {:ok, stream_id} = Stream.create_stream(conn, UUID.uuid4)
+    {:ok, stream_uuid, stream_id} = create_stream(conn)
 
-    {:ok, [1]} = Appender.append(conn, EventFactory.create_recorded_events(1, stream_id))
-    {:ok, [2]} = Appender.append(conn, EventFactory.create_recorded_events(1, stream_id, 2, 2))
+    {:ok, [1]} = Appender.append(conn, stream_id, EventFactory.create_recorded_events(1, stream_uuid))
+    {:ok, [2]} = Appender.append(conn, stream_id, EventFactory.create_recorded_events(1, stream_uuid, 2, 2))
   end
 
   test "append multiple events to existing stream, in separate writes", %{conn: conn} do
-    {:ok, stream_id} = Stream.create_stream(conn, UUID.uuid4)
+    {:ok, stream_uuid, stream_id} = create_stream(conn)
 
-    {:ok, [1, 2, 3]} = Appender.append(conn, EventFactory.create_recorded_events(3, stream_id))
-    {:ok, [4, 5, 6]} = Appender.append(conn, EventFactory.create_recorded_events(3, stream_id, 4, 4))
+    {:ok, [1, 2, 3]} = Appender.append(conn, stream_id, EventFactory.create_recorded_events(3, stream_uuid))
+    {:ok, [4, 5, 6]} = Appender.append(conn, stream_id, EventFactory.create_recorded_events(3, stream_uuid, 4, 4))
   end
 
   test "append events to different, new streams", %{conn: conn} do
-    {:ok, stream_id1} = Stream.create_stream(conn, UUID.uuid4)
-    {:ok, stream_id2} = Stream.create_stream(conn, UUID.uuid4)
+    {:ok, stream1_uuid, stream1_id} = create_stream(conn)
+    {:ok, stream2_uuid, stream2_id} = create_stream(conn)
 
-    {:ok, [1, 2]} = Appender.append(conn, EventFactory.create_recorded_events(2, stream_id1))
-    {:ok, [3, 4]} = Appender.append(conn, EventFactory.create_recorded_events(2, stream_id2, 3))
+    {:ok, [1, 2]} = Appender.append(conn, stream1_id, EventFactory.create_recorded_events(2, stream1_uuid))
+    {:ok, [3, 4]} = Appender.append(conn, stream2_id, EventFactory.create_recorded_events(2, stream2_uuid, 3))
   end
 
   test "append events to different, existing streams", %{conn: conn} do
-    {:ok, stream_id1} = Stream.create_stream(conn, UUID.uuid4)
-    {:ok, stream_id2} = Stream.create_stream(conn, UUID.uuid4)
+    {:ok, stream1_uuid, stream1_id} = create_stream(conn)
+    {:ok, stream2_uuid, stream2_id} = create_stream(conn)
 
-    {:ok, [1, 2]} = Appender.append(conn, EventFactory.create_recorded_events(2, stream_id1))
-    {:ok, [3, 4]} = Appender.append(conn, EventFactory.create_recorded_events(2, stream_id2, 3))
-    {:ok, [5, 6]} = Appender.append(conn, EventFactory.create_recorded_events(2, stream_id1, 5, 3))
-    {:ok, [7, 8]} = Appender.append(conn, EventFactory.create_recorded_events(2, stream_id2, 7, 3))
+    {:ok, [1, 2]} = Appender.append(conn, stream1_id, EventFactory.create_recorded_events(2, stream1_uuid))
+    {:ok, [3, 4]} = Appender.append(conn, stream2_id, EventFactory.create_recorded_events(2, stream2_uuid, 3))
+    {:ok, [5, 6]} = Appender.append(conn, stream1_id, EventFactory.create_recorded_events(2, stream1_uuid, 5, 3))
+    {:ok, [7, 8]} = Appender.append(conn, stream2_id, EventFactory.create_recorded_events(2, stream2_uuid, 7, 3))
   end
 
   test "append to new stream, but stream already exists", %{conn: conn} do
-    {:ok, stream_id} = Stream.create_stream(conn, UUID.uuid4)
-    events = EventFactory.create_recorded_events(1, stream_id)
+    {:ok, stream_uuid, stream_id} = create_stream(conn)
+    events = EventFactory.create_recorded_events(1, stream_uuid)
 
-    {:ok, [1]} = Appender.append(conn, events)
-    {:error, :wrong_expected_version} = Appender.append(conn, events)
+    {:ok, [1]} = Appender.append(conn, stream_id, events)
+    {:error, :wrong_expected_version} = Appender.append(conn, stream_id, events)
   end
 
   test "append to existing stream, but stream does not exist", %{conn: conn} do
+    stream_uuid = UUID.uuid4()
     stream_id = 1
-    events = EventFactory.create_recorded_events(1, stream_id)
+    events = EventFactory.create_recorded_events(1, stream_uuid)
 
-    {:error, :stream_not_found} = Appender.append(conn, events)
+    {:error, :stream_not_found} = Appender.append(conn, stream_id, events)
   end
 
   test "append to existing stream, but wrong expected version", %{conn: conn} do
-    {:ok, stream_id} = Stream.create_stream(conn, UUID.uuid4)
-    events = EventFactory.create_recorded_events(2, stream_id)
+    {:ok, stream_uuid, stream_id} = create_stream(conn)
+    events = EventFactory.create_recorded_events(2, stream_uuid)
 
-    {:ok, [1, 2]} = Appender.append(conn, events)
-    {:error, :wrong_expected_version} = Appender.append(conn, events)
+    {:ok, [1, 2]} = Appender.append(conn, stream_id, events)
+    {:error, :wrong_expected_version} = Appender.append(conn, stream_id, events)
+  end
+
+  defp create_stream(conn) do
+    stream_uuid = UUID.uuid4()
+    {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
+
+    {:ok, stream_uuid, stream_id}
   end
 end

--- a/test/storage/read_events_test.exs
+++ b/test/storage/read_events_test.exs
@@ -12,27 +12,27 @@ defmodule EventStore.Storage.ReadEventsTest do
     end
 
     test "when empty", %{conn: conn} do
-      {:ok, stream_id} = create_stream(conn)
+      {:ok, _stream_uuid, stream_id} = create_stream(conn)
 
-      {:ok, []} = Storage.read_stream_forward(stream_id, 0, 1_000)
+      assert {:ok, []} = Storage.read_stream_forward(stream_id, 0, 1_000)
     end
 
     test "with single event", %{conn: conn} do
-      {:ok, stream_id} = create_stream_containing_events(conn, 1)
+      {:ok, stream_uuid, stream_id} = create_stream_containing_events(conn, 1)
 
       {:ok, read_events} = Storage.read_stream_forward(stream_id, 0, 1_000)
 
       read_event = hd(read_events)
-      recorded_event = hd(EventFactory.create_recorded_events(1, stream_id))
+      recorded_event = hd(EventFactory.create_recorded_events(1, stream_uuid))
 
       assert read_event.event_id == 1
-      assert read_event.stream_id == 1
+      assert read_event.stream_uuid == stream_uuid
       assert read_event.data == recorded_event.data
       assert read_event.metadata == recorded_event.metadata
     end
 
     test "with multiple events from origin limited by count", %{conn: conn} do
-      {:ok, stream_id} = create_stream_containing_events(conn, 10)
+      {:ok, _stream_uuid, stream_id} = create_stream_containing_events(conn, 10)
 
       {:ok, read_events} = Storage.read_stream_forward(stream_id, 0, 5)
 
@@ -41,7 +41,7 @@ defmodule EventStore.Storage.ReadEventsTest do
     end
 
     test "with multiple events from stream version limited by count", %{conn: conn} do
-      {:ok, stream_id} = create_stream_containing_events(conn, 10)
+      {:ok, _stream_uuid, stream_id} = create_stream_containing_events(conn, 10)
 
       {:ok, read_events} = Storage.read_stream_forward(stream_id, 6, 5)
 
@@ -56,28 +56,28 @@ defmodule EventStore.Storage.ReadEventsTest do
     end
 
     test "with multiple events", %{conn: conn} do
-      {:ok, stream1_id} = create_stream(conn)
-      {:ok, stream2_id} = create_stream(conn)
+      {:ok, stream1_uuid, stream1_id} = create_stream(conn)
+      {:ok, stream2_uuid, stream2_id} = create_stream(conn)
 
-      {:ok, [1]} = Appender.append(conn, EventFactory.create_recorded_events(1, stream1_id))
-      {:ok, [2]} = Appender.append(conn, EventFactory.create_recorded_events(1, stream2_id, 2))
-      {:ok, [3]} = Appender.append(conn, EventFactory.create_recorded_events(1, stream1_id, 3, 2))
-      {:ok, [4]} = Appender.append(conn, EventFactory.create_recorded_events(1, stream2_id, 4, 2))
+      {:ok, [1]} = Appender.append(conn, stream1_id, EventFactory.create_recorded_events(1, stream1_uuid))
+      {:ok, [2]} = Appender.append(conn, stream2_id, EventFactory.create_recorded_events(1, stream2_uuid, 2))
+      {:ok, [3]} = Appender.append(conn, stream1_id, EventFactory.create_recorded_events(1, stream1_uuid, 3, 2))
+      {:ok, [4]} = Appender.append(conn, stream2_id, EventFactory.create_recorded_events(1, stream2_uuid, 4, 2))
 
       {:ok, events} = Storage.read_all_streams_forward(0, 1_000)
 
       assert length(events) == 4
       assert [1, 2, 3, 4] == Enum.map(events, &(&1.event_id))
-      assert [1, 2, 1, 2] == Enum.map(events, &(&1.stream_id))
+      assert [stream1_uuid, stream2_uuid, stream1_uuid, stream2_uuid] == Enum.map(events, &(&1.stream_uuid))
       assert [1, 1, 2, 2] == Enum.map(events, &(&1.stream_version))
     end
 
     test "with multiple events from after last event", %{conn: conn} do
-      {:ok, stream1_id} = create_stream(conn)
-      {:ok, stream2_id} = create_stream(conn)
+      {:ok, stream1_uuid, stream1_id} = create_stream(conn)
+      {:ok, stream2_uuid, stream2_id} = create_stream(conn)
 
-      {:ok, [1]} = Appender.append(conn, EventFactory.create_recorded_events(1, stream1_id))
-      {:ok, [2]} = Appender.append(conn, EventFactory.create_recorded_events(1, stream2_id, 2))
+      {:ok, [1]} = Appender.append(conn, stream1_id, EventFactory.create_recorded_events(1, stream1_uuid))
+      {:ok, [2]} = Appender.append(conn, stream2_id, EventFactory.create_recorded_events(1, stream2_uuid, 2))
 
       {:ok, events} = Storage.read_all_streams_forward(3, 1_000)
 
@@ -85,13 +85,13 @@ defmodule EventStore.Storage.ReadEventsTest do
     end
 
     test "with multiple events from after last event limited by count", %{conn: conn} do
-      {:ok, stream1_id} = create_stream(conn)
-      {:ok, stream2_id} = create_stream(conn)
+      {:ok, stream1_uuid, stream1_id} = create_stream(conn)
+      {:ok, stream2_uuid, stream2_id} = create_stream(conn)
 
-      {:ok, [1, 2, 3, 4, 5]} = Appender.append(conn, EventFactory.create_recorded_events(5, stream1_id))
-      {:ok, [6, 7, 8, 9, 10]} = Appender.append(conn, EventFactory.create_recorded_events(5, stream2_id, 6))
-      {:ok, [11, 12, 13, 14, 15]} = Appender.append(conn, EventFactory.create_recorded_events(5, stream1_id, 11, 6))
-      {:ok, [16, 17, 18, 19, 20]} = Appender.append(conn, EventFactory.create_recorded_events(5, stream2_id, 16, 6))
+      {:ok, [1, 2, 3, 4, 5]} = Appender.append(conn, stream1_id, EventFactory.create_recorded_events(5, stream1_uuid))
+      {:ok, [6, 7, 8, 9, 10]} = Appender.append(conn, stream2_id, EventFactory.create_recorded_events(5, stream2_uuid, 6))
+      {:ok, [11, 12, 13, 14, 15]} = Appender.append(conn, stream1_id, EventFactory.create_recorded_events(5, stream1_uuid, 11, 6))
+      {:ok, [16, 17, 18, 19, 20]} = Appender.append(conn, stream2_id, EventFactory.create_recorded_events(5, stream2_uuid, 16, 6))
 
       {:ok, events} = Storage.read_all_streams_forward(0, 10)
 
@@ -105,13 +105,20 @@ defmodule EventStore.Storage.ReadEventsTest do
     end
   end
 
-  defp create_stream(conn), do: Stream.create_stream(conn, UUID.uuid4)
+  defp create_stream(conn) do
+    stream_uuid = UUID.uuid4()
+
+    with {:ok, stream_id} <- Stream.create_stream(conn, stream_uuid) do
+      {:ok, stream_uuid, stream_id}
+    end
+  end
 
   defp create_stream_containing_events(conn, event_count) do
-    {:ok, stream_id} = create_stream(conn)
-    recorded_events = EventFactory.create_recorded_events(event_count, stream_id)
-    {:ok, _} = Appender.append(conn, recorded_events)
-    {:ok, stream_id}
+    {:ok, stream_uuid, stream_id} = create_stream(conn)
+    recorded_events = EventFactory.create_recorded_events(event_count, stream_uuid)
+    {:ok, _event_ids} = Appender.append(conn, stream_id, recorded_events)
+
+    {:ok, stream_uuid, stream_id}
   end
 
   defp pluck(enumerable, field), do: Enum.map(enumerable, &Map.get(&1, field))

--- a/test/storage/snapshot_test.exs
+++ b/test/storage/snapshot_test.exs
@@ -14,7 +14,7 @@ defmodule EventStore.Storage.SnapshotTest do
     test "should read successfully when present", %{conn: conn} do
       source_uuid = UUID.uuid4
       source_version = 1
-      recorded_event = hd(EventFactory.create_recorded_events(1, 1))
+      recorded_event = hd(EventFactory.create_recorded_events(1, source_uuid))
       :ok = Snapshot.record_snapshot(conn, %SnapshotData{source_uuid: source_uuid, source_version: source_version, source_type: recorded_event.event_type, data: recorded_event.data, metadata: recorded_event.metadata})
 
       {:ok, snapshot} = Snapshot.read_snapshot(conn, source_uuid)
@@ -31,14 +31,14 @@ defmodule EventStore.Storage.SnapshotTest do
     test "should record snapshot when none exists", %{conn: conn} do
       source_uuid = UUID.uuid4
       source_version = 1
-      recorded_event = hd(EventFactory.create_recorded_events(1, 1))
+      recorded_event = hd(EventFactory.create_recorded_events(1, source_uuid))
 
       :ok = Snapshot.record_snapshot(conn, %SnapshotData{source_uuid: source_uuid, source_version: source_version, source_type: recorded_event.event_type, data: recorded_event.data, metadata: recorded_event.metadata})
     end
 
     test "should modify snapshot when already exists", %{conn: conn} do
       source_uuid = UUID.uuid4
-      [recorded_event1, recorded_event2] = EventFactory.create_recorded_events(2, 1)
+      [recorded_event1, recorded_event2] = EventFactory.create_recorded_events(2, source_uuid)
 
       :ok = Snapshot.record_snapshot(conn, %SnapshotData{source_uuid: source_uuid, source_version: 1, source_type: recorded_event1.event_type, data: recorded_event1.data, metadata: recorded_event1.metadata})
       :ok = Snapshot.record_snapshot(conn, %SnapshotData{source_uuid: source_uuid, source_version: 2, source_type: recorded_event2.event_type, data: recorded_event2.data, metadata: recorded_event2.metadata})
@@ -52,8 +52,8 @@ defmodule EventStore.Storage.SnapshotTest do
 
   test "record snapshot when present should update existing", %{conn: conn} do
     source_uuid = UUID.uuid4
-    initial_recorded_event = hd(EventFactory.create_recorded_events(1, 1))
-    updated_recorded_event = hd(EventFactory.create_recorded_events(1, 1, 2))
+    initial_recorded_event = hd(EventFactory.create_recorded_events(1, source_uuid))
+    updated_recorded_event = hd(EventFactory.create_recorded_events(1, source_uuid, 2))
 
     :ok = Snapshot.record_snapshot(conn, %SnapshotData{source_uuid: source_uuid, source_version: 1, source_type: initial_recorded_event.event_type, data: initial_recorded_event.data, metadata: initial_recorded_event.metadata})
     :ok = Snapshot.record_snapshot(conn, %SnapshotData{source_uuid: source_uuid, source_version: 2, source_type: updated_recorded_event.event_type, data: updated_recorded_event.data, metadata: updated_recorded_event.metadata})
@@ -71,7 +71,7 @@ defmodule EventStore.Storage.SnapshotTest do
     test "should delete existing snapshot", %{conn: conn} do
       source_uuid = UUID.uuid4
       source_version = 1
-      recorded_event = hd(EventFactory.create_recorded_events(1, 1))
+      recorded_event = hd(EventFactory.create_recorded_events(1, source_uuid))
       :ok = Snapshot.record_snapshot(conn, %SnapshotData{source_uuid: source_uuid, source_version: source_version, source_type: recorded_event.event_type, data: recorded_event.data, metadata: recorded_event.metadata})
 
       :ok = Snapshot.delete_snapshot(conn, source_uuid)

--- a/test/storage/stream_persistence_test.exs
+++ b/test/storage/stream_persistence_test.exs
@@ -59,10 +59,10 @@ defmodule EventStore.Storage.StreamPersistenceTest do
   defp create_stream_with_events(conn, stream_uuid, number_of_events, initial_event_id \\ 1) do
     {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
 
-    recorded_events = EventFactory.create_recorded_events(number_of_events, stream_id, initial_event_id)
+    recorded_events = EventFactory.create_recorded_events(number_of_events, stream_uuid, initial_event_id)
     expected_event_ids = Enum.map(recorded_events, fn event -> event.event_id end)
 
-    {:ok, ^expected_event_ids} = Appender.append(conn, recorded_events)
+    {:ok, ^expected_event_ids} = Appender.append(conn, stream_id, recorded_events)
 
     {:ok, stream_id}
   end

--- a/test/streams/single_stream_test.exs
+++ b/test/streams/single_stream_test.exs
@@ -148,7 +148,7 @@ defmodule EventStore.Streams.StreamTest do
     test "from current should receive only new events", context do
       {:ok, _subscription} = Stream.subscribe_to_stream(context[:stream_uuid], @subscription_name, self(), start_from: :current)
 
-      refute_receive {:events, _received_events}
+      refute_received {:events, _received_events}
 
       events = EventFactory.create_events(1, 4)
       :ok = Stream.append_to_stream(context[:stream_uuid], 3, events)

--- a/test/subscriptions/all_streams_subscription_test.exs
+++ b/test/subscriptions/all_streams_subscription_test.exs
@@ -47,8 +47,8 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
   test "catch-up subscription, unseen persisted events", %{conn: conn} do
     stream_uuid = UUID.uuid4
     {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
-    recorded_events = EventFactory.create_recorded_events(3, stream_id)
-    {:ok, [1, 2, 3]} = Appender.append(conn, recorded_events)
+    recorded_events = EventFactory.create_recorded_events(3, stream_uuid)
+    {:ok, [1, 2, 3]} = Appender.append(conn, stream_id, recorded_events)
 
     subscription =
       create_subscription()
@@ -73,7 +73,8 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
   end
 
   test "notify events" do
-    events = EventFactory.create_recorded_events(1, 1)
+    stream_uuid = UUID.uuid4()
+    events = EventFactory.create_recorded_events(1, stream_uuid)
 
     subscription =
       create_subscription()
@@ -139,8 +140,8 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
       stream_uuid = UUID.uuid4
       {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
 
-      recorded_events = EventFactory.create_recorded_events(3, stream_id)
-      {:ok, [1, 2, 3]} = Appender.append(conn, recorded_events)
+      recorded_events = EventFactory.create_recorded_events(3, stream_uuid)
+      {:ok, [1, 2, 3]} = Appender.append(conn, stream_id, recorded_events)
 
       [recorded_events: recorded_events]
     end
@@ -166,7 +167,8 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
   end
 
   test "should not notify events until ack received" do
-    events = EventFactory.create_recorded_events(6, 1)
+    stream_uuid = UUID.uuid4
+    events = EventFactory.create_recorded_events(6, stream_uuid)
     initial_events = Enum.take(events, 3)
     remaining_events = Enum.drop(events, 3)
 
@@ -209,7 +211,8 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
 
   describe "pending event buffer limit" do
     test "should restrict pending events until ack" do
-      events = EventFactory.create_recorded_events(6, 1)
+      stream_uuid = UUID.uuid4
+      events = EventFactory.create_recorded_events(6, stream_uuid)
       initial_events = Enum.take(events, 3)
       remaining_events = Enum.drop(events, 3)
 
@@ -244,7 +247,8 @@ defmodule EventStore.Subscriptions.AllStreamsSubscriptionTest do
     end
 
     test "should receive pending events on ack after reaching max capacity" do
-      events = EventFactory.create_recorded_events(6, 1)
+      stream_uuid = UUID.uuid4
+      events = EventFactory.create_recorded_events(6, stream_uuid)
       initial_events = Enum.take(events, 3)
       remaining_events = Enum.drop(events, 3)
 

--- a/test/subscriptions/single_stream_subscription_test.exs
+++ b/test/subscriptions/single_stream_subscription_test.exs
@@ -116,7 +116,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     stream_uuid = UUID.uuid4
     {:ok, _stream} = Streams.Supervisor.open_stream(stream_uuid)
 
-    events = EventFactory.create_recorded_events(1, 1)
+    events = EventFactory.create_recorded_events(1, stream_uuid)
 
     subscription =
       create_subscription(stream_uuid)
@@ -197,8 +197,8 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
     stream_uuid = UUID.uuid4
     {:ok, stream_id} = Stream.create_stream(conn, stream_uuid)
 
-    recorded_events = EventFactory.create_recorded_events(3, stream_id, 4)
-    {:ok, [4, 5, 6]} = Appender.append(conn, recorded_events)
+    recorded_events = EventFactory.create_recorded_events(3, stream_uuid, 4)
+    {:ok, [4, 5, 6]} = Appender.append(conn, stream_id, recorded_events)
 
     {:ok, stream} = Streams.Supervisor.open_stream(stream_uuid)
 
@@ -231,7 +231,7 @@ defmodule EventStore.Subscriptions.SingleStreamSubscriptionTest do
 
   test "should not notify events until ack received" do
     stream_uuid = UUID.uuid4
-    events = EventFactory.create_recorded_events(6, 1)
+    events = EventFactory.create_recorded_events(6, stream_uuid)
     initial_events = Enum.take(events, 3)
     remaining_events = Enum.drop(events, 3)
 

--- a/test/support/event_factory.ex
+++ b/test/support/event_factory.ex
@@ -21,9 +21,11 @@ defmodule EventStore.EventFactory do
     end)
   end
 
-  def create_recorded_events(number_of_events, stream_id, initial_event_id \\ 1, initial_stream_version \\ 1) when number_of_events > 0 do
-    correlation_id = UUID.uuid4
-    causation_id = UUID.uuid4
+  def create_recorded_events(number_of_events, stream_uuid, initial_event_id \\ 1, initial_stream_version \\ 1)
+    when is_bitstring(stream_uuid) and number_of_events > 0
+  do
+    correlation_id = UUID.uuid4()
+    causation_id = UUID.uuid4()
 
     1..number_of_events
     |> Enum.map(fn number ->
@@ -32,7 +34,7 @@ defmodule EventStore.EventFactory do
 
       %RecordedEvent{
         event_id: event_id,
-        stream_id: stream_id,
+        stream_uuid: stream_uuid,
         stream_version: stream_version,
         correlation_id: correlation_id,
         causation_id: causation_id,


### PR DESCRIPTION
Use `stream_uuid`, not `stream_id`, for events read from storage. 

The `stream_id` is an internal identifier not necessary for consumers.