### PR TITLE
Append to stream with optional concurrency check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add `stream_version` column to `streams` table. It is used for stream info querying and optimistic concurrency checks, instead of querying the `events` table.
 
-### Upgrading
+### Upgrading
 
 Run the schema migration [v0.11.0.sql](scripts/upgrades/v0.11.0.sql) script against your event store database.
 

--- a/test/append_to_stream_test.exs
+++ b/test/append_to_stream_test.exs
@@ -1,0 +1,83 @@
+defmodule EventStore.AppendToStreamTest do
+  use EventStore.StorageCase
+
+  alias EventStore.EventFactory
+
+  describe "append to new stream using `:any_version`" do
+    test "should persist events" do
+      stream_uuid = UUID.uuid4()
+      events = EventFactory.create_events(3)
+
+      assert :ok = EventStore.append_to_stream(stream_uuid, :any_version, events)
+
+      assert {:ok, events} = EventStore.read_stream_forward(stream_uuid)
+      assert length(events) == 3
+    end
+  end
+
+  describe "append to existing stream using `:any_version`" do
+    setup [:append_events_to_stream]
+
+    test "should persist events", %{stream_uuid: stream_uuid} do
+      events = EventFactory.create_events(1)
+
+      assert :ok = EventStore.append_to_stream(stream_uuid, :any_version, events)
+
+      assert {:ok, events} = EventStore.read_stream_forward(stream_uuid)
+      assert length(events) == 4
+    end
+  end
+
+  describe "append to new stream using `:no_stream`" do
+    test "should persist events" do
+      stream_uuid = UUID.uuid4()
+      events = EventFactory.create_events(3)
+
+      assert :ok = EventStore.append_to_stream(stream_uuid, :no_stream, events)
+
+      assert {:ok, events} = EventStore.read_stream_forward(stream_uuid)
+      assert length(events) == 3
+    end
+  end
+
+  describe "append to existing stream using `:no_stream`" do
+    setup [:append_events_to_stream]
+
+    test "should return `{:error, :stream_exists}`", %{stream_uuid: stream_uuid} do
+      events = EventFactory.create_events(1)
+
+      assert {:error, :stream_exists} = EventStore.append_to_stream(stream_uuid, :no_stream, events)
+    end
+  end
+
+  describe "append to new stream using `:stream_exists`" do
+    test "should return `{:error, :stream_does_not_exist}`" do
+      stream_uuid = UUID.uuid4()
+      events = EventFactory.create_events(3)
+
+      assert {:error, :stream_does_not_exist} = EventStore.append_to_stream(stream_uuid, :stream_exists, events)
+    end
+  end
+
+  describe "append to existing stream using `:stream_exists`" do
+    setup [:append_events_to_stream]
+
+    test "should persist events`", %{stream_uuid: stream_uuid} do
+      events = EventFactory.create_events(1)
+
+      assert :ok = EventStore.append_to_stream(stream_uuid, :stream_exists, events)
+
+      assert {:ok, events} = EventStore.read_stream_forward(stream_uuid)
+      assert length(events) == 4
+    end
+  end
+
+  defp append_events_to_stream(_context) do
+    stream_uuid = UUID.uuid4
+    events = EventFactory.create_events(3)
+
+    :ok = EventStore.append_to_stream(stream_uuid, 0, events)
+
+    [stream_uuid: stream_uuid, events: events]
+  end
+end

--- a/test/streams/single_stream_test.exs
+++ b/test/streams/single_stream_test.exs
@@ -1,7 +1,5 @@
-defmodule EventStore.Streams.StreamTest do
+defmodule EventStore.Streams.SingleStreamTest do
   use EventStore.StorageCase
-  doctest EventStore.Streams.Supervisor
-  doctest EventStore.Streams.Stream
 
   alias EventStore.EventFactory
   alias EventStore.ProcessHelper

--- a/test/streams/single_stream_test.exs
+++ b/test/streams/single_stream_test.exs
@@ -146,7 +146,7 @@ defmodule EventStore.Streams.SingleStreamTest do
     test "from current should receive only new events", context do
       {:ok, _subscription} = Stream.subscribe_to_stream(context[:stream_uuid], @subscription_name, self(), start_from: :current)
 
-      refute_received {:events, _received_events}
+      refute_receive {:events, _received_events}
 
       events = EventFactory.create_events(1, 4)
       :ok = Stream.append_to_stream(context[:stream_uuid], 3, events)

--- a/test/support/process_helper.ex
+++ b/test/support/process_helper.ex
@@ -2,12 +2,15 @@ defmodule EventStore.ProcessHelper do
   import ExUnit.Assertions
 
   @doc """
-  Stop the given process with a non-normal exit reason
+  Stop the given process name with a non-normal exit reason
   """
   def shutdown(name) when is_atom(name) do
     name |> Process.whereis() |> shutdown()
   end
 
+  @doc """
+  Stop the given process with a non-normal exit reason
+  """
   def shutdown(pid) when is_pid(pid) do
     Process.unlink(pid)
     Process.exit(pid, :shutdown)


### PR DESCRIPTION
Allow `expected_version` in `EventStore.append_to_stream/3` to support the following options:

- `:any_version` - No concurrency checking; allow any stream version (including no stream).
- `:no_stream` - Ensure the stream does not exist.
- `:stream_exists` - Ensure the stream exists.
- Any non negative integer value - Optimistic concurrency check against stream's actual version (current behaviour).

### Example usage

```elixir
:ok = EventStore.append_to_stream(stream_uuid, :any_version, events)
```

Fixes #31. 