### PR TITLE
Append events in batches of 1,000

### DIFF
--- a/lib/event_store.ex
+++ b/lib/event_store.ex
@@ -18,8 +18,8 @@ defmodule EventStore do
 
   """
 
-  @type start_from :: :origin | :current | non_neg_integer()
   @type expected_version :: :any_version | :no_stream | :stream_exists | non_neg_integer()
+  @type start_from :: :origin | :current | non_neg_integer()
 
   alias EventStore.Snapshots.{SnapshotData,Snapshotter}
   alias EventStore.{EventData,RecordedEvent,Subscriptions}
@@ -59,16 +59,16 @@ defmodule EventStore do
       expected version was `:stream_exists`.
 
   """
-  @spec append_to_stream(String.t, expected_version, list(EventData.t)) :: :ok |
+  @spec append_to_stream(String.t, expected_version, list(EventData.t), timeout()) :: :ok |
     {:error, :wrong_expected_version} |
     {:error, :stream_exists} |
     {:error, :stream_does_not_exist} |
     {:error, reason :: term}
-  def append_to_stream(stream_uuid, expected_version, events)
-  def append_to_stream(@all_stream, _expected_version, _events), do: {:error, :cannot_append_to_all_stream}
-  def append_to_stream(stream_uuid, expected_version, events) do
+  def append_to_stream(stream_uuid, expected_version, events, timeout \\ 5_000)
+  def append_to_stream(@all_stream, _expected_version, _events, _timeout), do: {:error, :cannot_append_to_all_stream}
+  def append_to_stream(stream_uuid, expected_version, events, timeout) do
     with {:ok, _stream} <- EventStore.Streams.Supervisor.open_stream(stream_uuid) do
-      Stream.append_to_stream(stream_uuid, expected_version, events)
+      Stream.append_to_stream(stream_uuid, expected_version, events, timeout)
     else
       reply -> reply
     end

--- a/lib/event_store/publisher.ex
+++ b/lib/event_store/publisher.ex
@@ -5,8 +5,6 @@ defmodule EventStore.Publisher do
 
   use GenServer
 
-  require Logger
-
   alias EventStore.{Publisher,Storage,Subscriptions}
 
   defmodule PendingEvents do

--- a/lib/event_store/storage.ex
+++ b/lib/event_store/storage.ex
@@ -6,8 +6,6 @@ defmodule EventStore.Storage do
   This is for increased concurrency and performance, but with an upper limit on concurrent access.
   """
 
-  require Logger
-
   alias EventStore.Snapshots.SnapshotData
   alias EventStore.Storage
   alias EventStore.Storage.{Appender,Reader,Snapshot,Stream,Subscription}

--- a/lib/event_store/storage/initializer.ex
+++ b/lib/event_store/storage/initializer.ex
@@ -2,11 +2,12 @@ defmodule EventStore.Storage.Initializer do
   @moduledoc false
   alias EventStore.Sql.Statements
 
-  def run!(conn), do: execute(conn, Statements.initializers())
+  def run!(conn),
+    do: execute(conn, Statements.initializers())
 
-  def reset!(conn), do: execute(conn, Statements.reset())
+  def reset!(conn),
+    do: execute(conn, Statements.reset())
 
-  defp execute(conn, statements) do
-    Enum.each(statements, &(Postgrex.query!(conn, &1, [], pool: DBConnection.Poolboy)))
-  end
+  defp execute(conn, statements),
+    do: Enum.each(statements, &(Postgrex.query!(conn, &1, [], pool: DBConnection.Poolboy)))
 end

--- a/lib/event_store/storage/reader.ex
+++ b/lib/event_store/storage/reader.ex
@@ -36,12 +36,12 @@ defmodule EventStore.Storage.Reader do
   end
 
   defp failed_to_read(stream_id, reason) do
-    _ = Logger.warn(fn -> "failed to read events from stream id #{stream_id} due to #{inspect reason}" end)
+    _ = Logger.warn(fn -> "Failed to read events from stream id #{stream_id} due to #{inspect reason}" end)
     {:error, reason}
   end
 
   defp failed_to_read_all_stream(reason) do
-    _ = Logger.warn(fn -> "failed to read events from all streams due to #{inspect reason}" end)
+    _ = Logger.warn(fn -> "Failed to read events from all streams due to #{inspect reason}" end)
     {:error, reason}
   end
 
@@ -98,7 +98,7 @@ defmodule EventStore.Storage.Reader do
     end
 
     defp handle_response({:error, %Postgrex.Error{postgres: %{message: reason}}}) do
-      _ = Logger.warn(fn -> "failed to read events from stream due to: #{inspect reason}" end)
+      _ = Logger.warn(fn -> "Failed to read events from stream due to: #{inspect reason}" end)
       {:error, reason}
     end
   end

--- a/lib/event_store/storage/snapshot.ex
+++ b/lib/event_store/storage/snapshot.ex
@@ -60,7 +60,7 @@ defmodule EventStore.Storage.Snapshot do
     end
 
     defp handle_response({:error, error}, source_uuid, source_version) do
-      _ = Logger.warn(fn -> "failed to record snapshot for source \"#{source_uuid}\" at version \"#{source_version}\" due to: #{inspect error}" end)
+      _ = Logger.warn(fn -> "Failed to record snapshot for source \"#{source_uuid}\" at version \"#{source_version}\" due to: #{inspect error}" end)
       {:error, error}
     end
   end
@@ -77,7 +77,7 @@ defmodule EventStore.Storage.Snapshot do
     end
 
     defp handle_response({:error, error}, source_uuid) do
-      _ = Logger.warn(fn -> "failed to delete snapshot for source \"#{source_uuid}\" due to: #{inspect error}" end)
+      _ = Logger.warn(fn -> "Failed to delete snapshot for source \"#{source_uuid}\" due to: #{inspect error}" end)
       {:error, error}
     end
   end

--- a/lib/event_store/storage/stream.ex
+++ b/lib/event_store/storage/stream.ex
@@ -9,7 +9,7 @@ defmodule EventStore.Storage.Stream do
   alias EventStore.Storage.{QueryLatestEventId,QueryLatestStreamVersion,QueryStreamInfo,Reader}
 
   def create_stream(conn, stream_uuid) do
-    _ = Logger.debug(fn -> "attempting to create stream \"#{stream_uuid}\"" end)
+    _ = Logger.debug(fn -> "Attempting to create stream \"#{stream_uuid}\"" end)
 
     conn
     |> Postgrex.query(Statements.create_stream, [stream_uuid], pool: DBConnection.Poolboy)
@@ -44,17 +44,17 @@ defmodule EventStore.Storage.Stream do
   end
 
   defp handle_create_response({:ok, %Postgrex.Result{rows: [[stream_id]]}}, stream_uuid) do
-    _ = Logger.debug(fn -> "created stream \"#{stream_uuid}\" (id: #{stream_id})" end)
+    _ = Logger.debug(fn -> "Created stream \"#{stream_uuid}\" (id: #{stream_id})" end)
     {:ok, stream_id}
   end
 
   defp handle_create_response({:error, %Postgrex.Error{postgres: %{code: :unique_violation}}}, stream_uuid) do
-    _ = Logger.warn(fn -> "failed to create stream \"#{stream_uuid}\", already exists" end)
+    _ = Logger.warn(fn -> "Failed to create stream \"#{stream_uuid}\", already exists" end)
     {:error, :stream_exists}
   end
 
   defp handle_create_response({:error, error}, stream_uuid) do
-    _ = Logger.warn(fn -> "failed to create stream \"#{stream_uuid}\"" end)
+    _ = Logger.warn(fn -> "Failed to create stream \"#{stream_uuid}\"" end)
     {:error, error}
   end
 
@@ -65,7 +65,7 @@ defmodule EventStore.Storage.Stream do
   end
 
   defp handle_lookup_response({:ok, %Postgrex.Result{num_rows: 0}}, stream_uuid) do
-    _ = Logger.warn(fn -> "attempted to access unknown stream \"#{stream_uuid}\"" end)
+    _ = Logger.warn(fn -> "Attempted to access unknown stream \"#{stream_uuid}\"" end)
     {:error, :stream_not_found}
   end
 

--- a/lib/event_store/storage/subscription.ex
+++ b/lib/event_store/storage/subscription.ex
@@ -82,7 +82,7 @@ defmodule EventStore.Storage.Subscription do
 
   defmodule Subscribe do
     def execute(conn, stream_uuid, subscription_name, start_from_event_id, start_from_stream_version) do
-      _ = Logger.debug(fn -> "attempting to create subscription on stream \"#{stream_uuid}\" named \"#{subscription_name}\"" end)
+      _ = Logger.debug(fn -> "Attempting to create subscription on stream \"#{stream_uuid}\" named \"#{subscription_name}\"" end)
 
       conn
       |> Postgrex.query(Statements.create_subscription, [stream_uuid, subscription_name, start_from_event_id, start_from_stream_version], pool: DBConnection.Poolboy)
@@ -90,17 +90,17 @@ defmodule EventStore.Storage.Subscription do
     end
 
     defp handle_response({:ok, %Postgrex.Result{rows: rows}}, stream_uuid, subscription_name) do
-      _ = Logger.debug(fn -> "created subscription on stream \"#{stream_uuid}\" named \"#{subscription_name}\"" end)
+      _ = Logger.debug(fn -> "Created subscription on stream \"#{stream_uuid}\" named \"#{subscription_name}\"" end)
       {:ok, Subscription.Adapter.to_subscription(rows)}
     end
 
     defp handle_response({:error, %Postgrex.Error{postgres: %{code: :unique_violation}}}, stream_uuid, subscription_name) do
-      _ = Logger.warn(fn -> "failed to create subscription on stream #{stream_uuid} named #{subscription_name}, already exists" end)
+      _ = Logger.warn(fn -> "Failed to create subscription on stream #{stream_uuid} named #{subscription_name}, already exists" end)
       {:error, :subscription_already_exists}
     end
 
     defp handle_response({:error, error}, stream_uuid, subscription_name) do
-      _ = Logger.warn(fn -> "failed to create stream create subscription on stream \"#{stream_uuid}\" named \"#{subscription_name}\" due to: #{error}" end)
+      _ = Logger.warn(fn -> "Failed to create stream create subscription on stream \"#{stream_uuid}\" named \"#{subscription_name}\" due to: #{error}" end)
       {:error, error}
     end
   end
@@ -117,14 +117,14 @@ defmodule EventStore.Storage.Subscription do
     end
 
     defp handle_response({:error, error}, stream_uuid, subscription_name) do
-      _ = Logger.warn(fn -> "failed to ack last seen event on stream \"#{stream_uuid}\" named \"#{subscription_name}\" due to: #{error}" end)
+      _ = Logger.warn(fn -> "Failed to ack last seen event on stream \"#{stream_uuid}\" named \"#{subscription_name}\" due to: #{error}" end)
       {:error, error}
     end
   end
 
   defmodule Unsubscribe do
     def execute(conn, stream_uuid, subscription_name) do
-      _ = Logger.debug(fn -> "attempting to unsubscribe from stream \"#{stream_uuid}\" named \"#{subscription_name}\"" end)
+      _ = Logger.debug(fn -> "Attempting to unsubscribe from stream \"#{stream_uuid}\" named \"#{subscription_name}\"" end)
 
       conn
       |> Postgrex.query(Statements.delete_subscription, [stream_uuid, subscription_name], pool: DBConnection.Poolboy)
@@ -132,12 +132,12 @@ defmodule EventStore.Storage.Subscription do
     end
 
     defp handle_response({:ok, _result}, stream_uuid, subscription_name) do
-      _ = Logger.debug(fn -> "unsubscribed from stream \"#{stream_uuid}\" named \"#{subscription_name}\"" end)
+      _ = Logger.debug(fn -> "Unsubscribed from stream \"#{stream_uuid}\" named \"#{subscription_name}\"" end)
       :ok
     end
 
     defp handle_response({:error, error}, stream_uuid, subscription_name) do
-      _ = Logger.warn(fn -> "failed to unsubscribe from stream \"#{stream_uuid}\" named \"#{subscription_name}\" due to: #{error}" end)
+      _ = Logger.warn(fn -> "Failed to unsubscribe from stream \"#{stream_uuid}\" named \"#{subscription_name}\" due to: #{error}" end)
       {:error, error}
     end
   end

--- a/lib/event_store/streams/all_stream.ex
+++ b/lib/event_store/streams/all_stream.ex
@@ -3,8 +3,6 @@ defmodule EventStore.Streams.AllStream do
   A logical stream containing events appended to all streams
   """
 
-  require Logger
-
   alias EventStore.{RecordedEvent,Storage}
   alias EventStore.Subscriptions
 

--- a/lib/event_store/streams/stream.ex
+++ b/lib/event_store/streams/stream.ex
@@ -6,8 +6,6 @@ defmodule EventStore.Streams.Stream do
   use GenServer
   use EventStore.Registration
 
-  require Logger
-
   alias EventStore.{EventData,RecordedEvent,Storage,Subscriptions,Writer}
   alias EventStore.Streams.Stream
 
@@ -36,8 +34,9 @@ defmodule EventStore.Streams.Stream do
 
   Returns `:ok` on success.
   """
-  def append_to_stream(stream_uuid, expected_version, events) do
-    GenServer.call(via_name(stream_uuid), {:append_to_stream, expected_version, events})
+  def append_to_stream(stream_uuid, expected_version, events, timeout \\ 5_000)
+  def append_to_stream(stream_uuid, expected_version, events, timeout) do
+    GenServer.call(via_name(stream_uuid), {:append_to_stream, expected_version, events}, timeout)
   end
 
   def read_stream_forward(stream_uuid, start_version, count) do

--- a/lib/event_store/streams/supervisor.ex
+++ b/lib/event_store/streams/supervisor.ex
@@ -4,9 +4,7 @@ defmodule EventStore.Streams.Supervisor do
   """
 
   use Supervisor
-
-  require Logger
-
+  
   alias EventStore.Registration
   alias EventStore.Streams.Stream
 

--- a/lib/event_store/subscriptions.ex
+++ b/lib/event_store/subscriptions.ex
@@ -37,7 +37,7 @@ defmodule EventStore.Subscriptions do
   end
 
   defp do_subscribe_to_stream(stream_uuid, subscription_name, subscriber, opts) do
-    _ = Logger.debug(fn -> "creating subscription process on stream #{inspect stream_uuid} named: #{inspect subscription_name}" end)
+    _ = Logger.debug(fn -> "Creating subscription process on stream #{inspect stream_uuid} named: #{inspect subscription_name}" end)
 
     case EventStore.Subscriptions.Supervisor.subscribe_to_stream(stream_uuid, subscription_name, subscriber, opts) do
       {:ok, subscription} -> {:ok, subscription}

--- a/lib/event_store/subscriptions/stream_subscription.ex
+++ b/lib/event_store/subscriptions/stream_subscription.ex
@@ -1,7 +1,5 @@
 defmodule EventStore.Subscriptions.StreamSubscription do
   @moduledoc false
-  require Logger
-
   alias EventStore.{
     RecordedEvent,
     Storage,

--- a/mix.exs
+++ b/mix.exs
@@ -103,7 +103,8 @@ EventStore using PostgreSQL for persistence.
       "es.reset":           ["event_store.drop", "event_store.create"],
       "event_store.reset":  ["event_store.drop", "event_store.create"],
       "benchmark":          ["es.reset", "app.start", "bench"],
-      "test.all":           &test_registries/1,
+      "test.all":           ["test.registries", "test --only slow"],
+      "test.registries":    &test_registries/1,
       "test.distributed":   &test_distributed/1,
       "test.local":         &test_local/1,
     ]

--- a/test/append_to_stream_test.exs
+++ b/test/append_to_stream_test.exs
@@ -72,6 +72,17 @@ defmodule EventStore.AppendToStreamTest do
     end
   end
 
+  @tag :slow
+  @tag timeout: 180_000
+  test "should append many events to a stream" do
+    stream_uuid = UUID.uuid4
+    events = EventFactory.create_events(8_001)
+
+    assert :ok = EventStore.append_to_stream(stream_uuid, 0, events, :infinity)
+
+    assert 1..8_001 |> Enum.to_list() == EventStore.stream_all_forward() |> Stream.map(&(&1.event_id)) |> Enum.to_list()
+  end
+
   defp append_events_to_stream(_context) do
     stream_uuid = UUID.uuid4
     events = EventFactory.create_events(3)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.start(exclude: [:distributed])
+ExUnit.start(exclude: [:distributed, :slow])
 
 Mix.Task.run("event_store.create", ~w(--quiet))
 


### PR DESCRIPTION
This is due to Postgres' limit of 65,535 parameters in a single statement. Inserting events in batches circumvents this limit to allow an unlimited number of events to be appended to a stream in a single append.

The `INSERT` SQL statement will guarantee that the events are atomically inserted with contiguous event ids, even across batches, if more than 1,000 events are inserted in one request.

Fixes #77.