### PR TITLE
Separate `create` and `init` mix tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ services:
 
 before_script:
   - MIX_ENV=test mix event_store.create
+  - MIX_ENV=test mix event_store.init
   - epmd -daemon
 
 script:

--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -28,8 +28,13 @@ EventStore is [available in Hex](https://hex.pm/packages/eventstore) and can be 
   - `:pool_size` - The number of connections (default: `10`).
   - `:pool_overflow` - The maximum number of overflow connections to start if all connections are checked out (default: `0`).
 
-  3. Create the EventStore database and tables using the `mix` task:
+  3. Create the EventStore database using the `mix` task:
 
       ```console
       $ mix event_store.create
       ```
+
+  4. Initialize the EventStore tables using the `mix` task:
+
+      ```console
+      $ mix event_store.init

--- a/lib/mix/tasks/event_store.create.ex
+++ b/lib/mix/tasks/event_store.create.ex
@@ -14,7 +14,6 @@ defmodule Mix.Tasks.EventStore.Create do
 
   use Mix.Task
 
-  alias EventStore.Storage
   alias EventStore.Storage.Database
 
   @shortdoc "Create the database for the EventStore"
@@ -38,8 +37,6 @@ defmodule Mix.Tasks.EventStore.Create do
           Mix.shell.info "The EventStore database has been created."
         end
 
-        initialize_storage!(config)
-
       {:error, :already_up} ->
         unless opts[:quiet] do
           Mix.shell.info "The EventStore database already exists."
@@ -48,11 +45,5 @@ defmodule Mix.Tasks.EventStore.Create do
       {:error, term} ->
         Mix.raise "The EventStore database couldn't be created, reason given: #{inspect term}."
     end
-  end
-
-  defp initialize_storage!(config) do
-    {:ok, conn} = Postgrex.start_link(config)
-
-    Storage.Initializer.run!(conn)
   end
 end

--- a/lib/mix/tasks/event_store.init.ex
+++ b/lib/mix/tasks/event_store.init.ex
@@ -1,0 +1,42 @@
+defmodule Mix.Tasks.EventStore.Init do
+  @moduledoc """
+  Initialize the database for the EventStore.
+
+  ## Examples
+
+      mix event_store.init
+
+  ## Command line options
+
+    * `--quiet` - do not log output
+
+  """
+
+  use Mix.Task
+
+  alias EventStore.Storage
+
+  @shortdoc "Initialize the database for the EventStore"
+
+  @doc false
+  def run(args) do
+    {:ok, _} = Application.ensure_all_started(:postgrex)
+
+    config = EventStore.configuration() |> EventStore.Config.parse()
+    {opts, _, _} = OptionParser.parse(args, switches: [quiet: :boolean])
+
+    initialize_storage!(config, opts)
+
+    Mix.Task.reenable "event_store.init"
+  end
+
+  defp initialize_storage!(config, opts) do
+    {:ok, conn} = Postgrex.start_link(config)
+
+    Storage.Initializer.run!(conn)
+
+    unless opts[:quiet] do
+      Mix.shell.info "The EventStore database has been initialized."
+    end
+  end
+end


### PR DESCRIPTION
It allows to initialize an existing database.

Fixes #41